### PR TITLE
Fix trailing comment in time_zone_struct

### DIFF
--- a/include/time_shield_cpp/time_shield/time_zone_struct.hpp
+++ b/include/time_shield_cpp/time_shield/time_zone_struct.hpp
@@ -111,4 +111,4 @@ namespace time_shield {
 
 }; // namespace time_shield
 
-#endif // _TIME_SHIELD_TIME_STRUCT_HPP_INCLUDED
+#endif // _TIME_SHIELD_TIME_ZONE_STRUCT_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- correct the closing comment in `time_zone_struct.hpp`

## Testing
- `cmake -S . -B build`
- `cmake --build build` (no output, nothing built)

------
https://chatgpt.com/codex/tasks/task_e_685526d67c24832cb915b4864f8fc6d5