### PR TITLE
Add time zone struct for MQL5

### DIFF
--- a/MQL5/Include/time_shield/constants.mqh
+++ b/MQL5/Include/time_shield/constants.mqh
@@ -1,0 +1,135 @@
+//+------------------------------------------------------------------+
+//|                                            constants.mqh         |
+//|                     Time Shield - MQL5 Constants                 |
+//|                                      Copyright 2025, NewYaroslav |
+//|                   https://github.com/NewYaroslav/time-shield-cpp |
+//+------------------------------------------------------------------+
+#ifndef __TIME_SHIELD_CONSTANTS_MQH__
+#define __TIME_SHIELD_CONSTANTS_MQH__
+
+/// \file constants.mqh
+/// \ingroup mql5
+/// \brief Header file with time-related constants.
+///
+/// This file contains various constants used for time calculations and conversions.
+
+#property copyright "Copyright 2025, NewYaroslav"
+#property link      "https://github.com/NewYaroslav/time-shield-cpp"
+#property strict
+
+namespace time_shield {
+
+    /// \defgroup time_constants Time Constants
+    /// \brief A collection of constants for time calculations and conversions.
+    ///
+    /// This group includes constants for time units (nanoseconds, microseconds, milliseconds, seconds, minutes, hours, days),
+    /// and other values related to the representation of time, such as UNIX and OLE epochs.
+    ///
+    /// ### Key Features:
+    /// - Provides constants for common time conversions.
+    /// - Includes limits and special values like MAX_YEAR and ERROR_YEAR.
+    ///
+    /// ### Example Usage:
+    /// \code
+    /// long milliseconds_in_a_day = time_shield::MS_PER_DAY;
+    /// \endcode
+    ///
+    /// \{
+
+    // Nanoseconds and microseconds
+    const long NS_PER_US     = 1000;         ///< Nanoseconds per microsecond
+    const long NS_PER_MS     = 1000000;      ///< Nanoseconds per millisecond
+    const long NS_PER_SEC    = 1000000000;   ///< Nanoseconds per second
+
+    // Microseconds and milliseconds
+    const long US_PER_SEC        = 1000000;  ///< Microseconds per second
+    const long MS_PER_SEC        = 1000;     ///< Milliseconds per second
+    const long MS_PER_1_SEC      = 1000;     ///< Milliseconds per 1 second
+    const long MS_PER_5_SEC      = 5000;     ///< Milliseconds per 5 second
+    const long MS_PER_10_SEC     = 10000;    ///< Milliseconds per 10 seconds
+    const long MS_PER_15_SEC     = 15000;    ///< Milliseconds per 15 second
+    const long MS_PER_30_SEC     = 30000;    ///< Milliseconds per 30 second
+    const long MS_PER_MIN        = 60000;    ///< Milliseconds per minute
+    const long MS_PER_1_MIN      = 60000;    ///< Milliseconds per 1 minute
+    const long MS_PER_5_MIN      = 300000;   ///< Milliseconds per 5 minute
+    const long MS_PER_10_MIN     = 600000;   ///< Milliseconds per 10 minute
+    const long MS_PER_15_MIN     = 900000;   ///< Milliseconds per 15 minute
+    const long MS_PER_30_MIN     = 1800000;  ///< Milliseconds per 30 minute
+    const long MS_PER_HALF_HOUR  = 1800000;  ///< Milliseconds per half hour
+    const long MS_PER_HOUR       = 3600000;  ///< Milliseconds per hour
+    const long MS_PER_1_HOUR     = 3600000;  ///< Milliseconds per 1 hour
+    const long MS_PER_2_HOUR     = 7200000;  ///< Milliseconds per 2 hour
+    const long MS_PER_4_HOUR     = 14400000; ///< Milliseconds per 4 hour
+    const long MS_PER_5_HOUR     = 18000000; ///< Milliseconds per 5 hour
+    const long MS_PER_8_HOUR     = 28800000; ///< Milliseconds per 8 hour
+    const long MS_PER_12_HOUR    = 43200000; ///< Milliseconds per 12 hour
+    const long MS_PER_DAY        = 86400000; ///< Milliseconds per day
+
+    // Seconds
+    const long SEC_PER_MIN       = 60;       ///< Seconds per minute
+    const long SEC_PER_1_MIN     = 60;       ///< Seconds per 1 minute
+    const long SEC_PER_3_MIN     = 180;      ///< Seconds per 3 minute
+    const long SEC_PER_5_MIN     = 300;      ///< Seconds per 5 minute
+    const long SEC_PER_10_MIN    = 600;      ///< Seconds per 10 minute
+    const long SEC_PER_15_MIN    = 900;      ///< Seconds per 15 minute
+    const long SEC_PER_HALF_HOUR = 1800;     ///< Seconds per half hour
+    const long SEC_PER_HOUR      = 3600;     ///< Seconds per hour
+    const long SEC_PER_1_HOUR    = 3600;     ///< Seconds per 1 hour
+    const long SEC_PER_2_HOUR    = 7200;     ///< Seconds per 2 hour
+    const long SEC_PER_4_HOUR    = 14400;    ///< Seconds per 4 hour
+    const long SEC_PER_5_HOUR    = 18000;    ///< Seconds per 5 hour
+    const long SEC_PER_8_HOUR    = 28800;    ///< Seconds per 8 hour
+    const long SEC_PER_12_HOUR   = 43200;    ///< Seconds per 12 hour
+    const long SEC_PER_DAY       = 86400;    ///< Seconds per day
+    const long SEC_PER_YEAR      = 31536000; ///< Seconds per year (365 days)
+    const long AVG_SEC_PER_YEAR  = 31557600; ///< Average seconds per year (365.25 days)
+    const long SEC_PER_LEAP_YEAR = 31622400; ///< Seconds per leap year (366 days)
+    const long SEC_PER_4_YEARS   = 126230400; ///< Seconds per 4 years
+    const long SEC_PER_FIRST_100_YEARS = 3155760000; ///< Seconds per first 100 years
+    const long SEC_PER_100_YEARS = 3155673600;   ///< Seconds per 100 years
+    const long SEC_PER_400_YEARS = 12622780800;  ///< Seconds per 400 years
+    const long MAX_SEC_PER_DAY   = 86399;    ///< Maximum seconds per day
+
+    // Minutes
+    const long MIN_PER_HOUR      = 60;       ///< Minutes per hour
+    const long MIN_PER_DAY       = 1440;     ///< Minutes per day
+    const long MIN_PER_1_DAY     = 1440;     ///< Minutes per 1 day
+    const long MIN_PER_2_DAY     = 2*1440;   ///< Minutes per 2 day
+    const long MIN_PER_5_DAY     = 5*1440;   ///< Minutes per 5 day
+    const long MIN_PER_7_DAY     = 7*1440;   ///< Minutes per 7 day
+    const long MIN_PER_WEEK      = 10080;    ///< Minutes per week
+    const long MIN_PER_10_DAY    = 10*1440;  ///< Minutes per 10 day
+    const long MIN_PER_15_DAY    = 15*1440;  ///< Minutes per 15 day
+    const long MIN_PER_30_DAY    = 15*1440;  ///< Minutes per 30 day
+    const long MIN_PER_MONTH     = 40320;    ///< Minutes per month (28 days)
+    const long MAX_MOON_MIN      = 42523;    ///< Maximum lunar minutes
+
+    // Hours and days
+    const long HOURS_PER_DAY     = 24;       ///< Hours per day
+    const long DAYS_PER_WEEK     = 7;        ///< Days per week
+    const long DAYS_PER_LEAP_YEAR = 366;     ///< Days per leap year
+    const long DAYS_PER_YEAR     = 365;      ///< Days per year
+    const long DAYS_PER_4_YEARS  = 1461;     ///< Days per 4 years
+
+    // Months and years
+    const long MONTHS_PER_YEAR       = 12;   ///< Months per year
+    const long MAX_DAYS_PER_MONTH    = 31;   ///< Maximum days per month
+    const long LEAP_YEAR_PER_100_YEAR = 24;  ///< Leap years per 100 years
+    const long LEAP_YEAR_PER_400_YEAR = 97;  ///< Leap years per 400 years
+
+    // Epoch and maximum values
+    const long UNIX_EPOCH        = 1970;     ///< Start year of UNIX time
+    const long OLE_EPOCH         = 25569;    ///< OLE automation date since UNIX epoch
+    const long MAX_YEAR          = 292277022000;   ///< Maximum representable year
+    const long MIN_YEAR          = -2967369602200; ///< Minimum representable year
+    const long ERROR_YEAR        = 9223372036854770000; ///< Error year value
+    const long MAX_TIMESTAMP     = 9223371890843040000; ///< Maximum timestamp value
+    const long ERROR_TIMESTAMP   = 9223372036854770000; ///< Error timestamp value
+    const double MAX_OADATE      = 1.7976931348623158e+308; ///< Maximum OLE automation date
+    const double AVG_DAYS_PER_YEAR  = 365.25;   ///< Average days per year
+
+    /// \}
+
+}; // namespace time_shield
+
+#endif // __TIME_SHIELD_CONSTANTS_MQH__

--- a/MQL5/Include/time_shield/date_time_struct.mqh
+++ b/MQL5/Include/time_shield/date_time_struct.mqh
@@ -1,0 +1,67 @@
+//+------------------------------------------------------------------+
+//|                                       date_time_struct.mqh       |
+//|                      Time Shield - MQL5 DateTime Structure       |
+//|                                      Copyright 2025, NewYaroslav |
+//|                   https://github.com/NewYaroslav/time-shield-cpp |
+//+------------------------------------------------------------------+
+#ifndef __TIME_SHIELD_DATE_TIME_STRUCT_MQH__
+#define __TIME_SHIELD_DATE_TIME_STRUCT_MQH__
+
+/// \file date_time_struct.mqh
+/// \ingroup mql5
+/// \brief Header for date and time structure and related functions (MQL5).
+///
+/// This file contains the definition of the `DateTimeStruct` structure and
+/// a function to create `DateTimeStruct` instances for working with
+/// combined date and time values in MQL5.
+
+#property copyright "Copyright 2025, NewYaroslav"
+#property link      "https://github.com/NewYaroslav/time-shield-cpp"
+#property strict
+
+namespace time_shield {
+
+    /// \ingroup time_structures
+    /// \brief Structure to represent date and time in MQL5.
+    struct DateTimeStruct {
+       long year;   ///< Year component of the date.
+       int  mon;    ///< Month component of the date (1-12).
+       int  day;    ///< Day component of the date (1-31).
+       int  hour;   ///< Hour component of time (0-23).
+       int  min;    ///< Minute component of time (0-59).
+       int  sec;    ///< Second component of time (0-59).
+       int  ms;     ///< Millisecond component of time (0-999).
+    };
+
+    /// \ingroup time_structures
+    /// \brief Creates a `DateTimeStruct` instance.
+    /// \param year The year component of the date.
+    /// \param mon The month component of the date, defaults to 1 (January).
+    /// \param day The day component of the date, defaults to 1.
+    /// \param hour The hour component of the time, defaults to 0.
+    /// \param min The minute component of the time, defaults to 0.
+    /// \param sec The second component of the time, defaults to 0.
+    /// \param ms The millisecond component of the time, defaults to 0.
+    /// \return A `DateTimeStruct` instance with the provided date and time components.
+    DateTimeStruct create_date_time_struct(
+            const long year,
+            const int mon = 1,
+            const int day = 1,
+            const int hour = 0,
+            const int min = 0,
+            const int sec = 0,
+            const int ms  = 0) {
+       DateTimeStruct result;
+       result.year = year;
+       result.mon  = mon;
+       result.day  = day;
+       result.hour = hour;
+       result.min  = min;
+       result.sec  = sec;
+       result.ms   = ms;
+       return result;
+    }
+
+}; // namespace time_shield
+
+#endif // __TIME_SHIELD_DATE_TIME_STRUCT_MQH__

--- a/MQL5/Include/time_shield/enums.mqh
+++ b/MQL5/Include/time_shield/enums.mqh
@@ -1,0 +1,207 @@
+//+------------------------------------------------------------------+
+//|                                                enums.mqh         |
+//|                        Time Shield - MQL5 Enumerations           |
+//|                                      Copyright 2025, NewYaroslav |
+//|                   https://github.com/NewYaroslav/time-shield-cpp |
+//+------------------------------------------------------------------+
+#ifndef __TIME_SHIELD_ENUMS_MQH__
+#define __TIME_SHIELD_ENUMS_MQH__
+
+/// \file enums.mqh
+/// \ingroup mql5
+/// \brief Header file with enumerations for weekdays, months, and other time-related categories.
+///
+/// This file contains enum definitions for representing various time-related concepts.
+
+#property copyright "Copyright 2025, NewYaroslav"
+#property link      "https://github.com/NewYaroslav/time-shield-cpp"
+#property strict
+
+namespace time_shield {
+
+    /// \defgroup time_enums Time Enumerations
+    /// \brief Enumerations for time-related concepts.
+    ///
+    /// This group contains various enums that represent time-related concepts such as
+    /// weekdays, months, time zones, and formatting options.
+    ///
+    /// ### Key Features:
+    /// - Defines enumerations for consistent handling of weekdays, months, and other time units.
+    /// - Provides utility functions for converting enum values to string representations.
+    ///
+    /// ### Example Usage:
+    /// \code
+    /// Weekday weekday = MON;
+    /// Print(time_shield::to_str(weekday, FormatType::FULL_NAME)); // "Monday"
+    /// \endcode
+    /// \{
+
+    /// Enumeration of the format options for representing a weekday or month.
+    enum FormatType {
+        UPPERCASE_NAME = 0, ///< Uppercase short name
+        SHORT_NAME,         ///< Short name
+        FULL_NAME,          ///< Full name
+    };
+
+    /// Enumeration of the days of the week.
+    enum Weekday {
+        SUN = 0,    ///< Sunday
+        MON,        ///< Monday
+        TUE,        ///< Tuesday
+        WED,        ///< Wednesday
+        THU,        ///< Thursday
+        FRI,        ///< Friday
+        SAT         ///< Saturday
+    };
+
+    /// \brief Converts a Weekday enum value to a string.
+    ///
+    /// \param value The Weekday enum value to convert.
+    /// \param format The format to use for the string representation (default is UPPERCASE_NAME).
+    /// \return A string with the representation of the day.
+    string to_str(Weekday value, FormatType format = UPPERCASE_NAME) {
+        static const string uppercase_names[] = {
+            "SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"
+        };
+        static const string short_names[] = {
+            "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+        };
+        static const string full_names[] = {
+            "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+        };
+        switch(format) {
+        default:
+        case UPPERCASE_NAME:
+            return uppercase_names[(int)value];
+        case SHORT_NAME:
+            return short_names[(int)value];
+        case FULL_NAME:
+            return full_names[(int)value];
+        }
+        return "";
+    }
+
+
+    /// Enumeration of the months of the year.
+    enum Month {
+        JAN = 1,    ///< January
+        FEB,        ///< February
+        MAR,        ///< March
+        APR,        ///< April
+        MAY,        ///< May
+        JUN,        ///< June
+        JUL,        ///< July
+        AUG,        ///< August
+        SEP,        ///< September
+        OCT,        ///< October
+        NOV,        ///< November
+        DEC         ///< December
+    };
+
+    /// \brief Converts a Month enum value to a string.
+    ///
+    /// \param value The Month enum value to convert.
+    /// \param format The format to use for the string representation (default is UPPERCASE_NAME).
+    /// \return A string with the representation of the month.
+    string to_str(Month value, FormatType format = UPPERCASE_NAME) {
+        static const string uppercase_names[] = {
+            "",
+            "JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+            "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"
+        };
+        static const string short_names[] = {
+            "",
+            "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+        };
+        static const string full_names[] = {
+            "",
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December"
+        };
+        switch(format) {
+        default:
+        case UPPERCASE_NAME:
+            return uppercase_names[(int)value];
+        case SHORT_NAME:
+            return short_names[(int)value];
+        case FULL_NAME:
+            return full_names[(int)value];
+        }
+        return "";
+    }
+
+
+    /// Enumeration of the time zones.
+    enum TimeZone {
+        GMT,    ///< Greenwich Mean Time
+        UTC,    ///< Coordinated Universal Time
+        EET,    ///< Eastern European Time
+        CET,    ///< Central European Time
+        WET,    ///< Western European Time
+        EEST,   ///< Eastern European Summer Time
+        CEST,   ///< Central European Summer Time
+        WEST,   ///< Western European Summer Time
+        UNKNOWN ///< Unknown Time Zone
+    };
+
+    /// \brief Converts a TimeZone enum value to a string.
+    ///
+    /// \param value The TimeZone enum value to convert.
+    /// \param format The format to use for the string representation (default is UPPERCASE_NAME).
+    /// \return A string with the representation of the time zone.
+    string to_str(TimeZone value, FormatType format = UPPERCASE_NAME) {
+        static const string uppercase_names[] = {
+            "GMT", "UTC", "EET", "CET", "WET", "EEST", "CEST", "WEST", "UNKNOWN"
+        };
+        static const string short_names[] = {
+            "GMT", "UTC", "EET", "CET", "WET", "EEST", "CEST", "WEST", "Unknown"
+        };
+        static const string full_names[] = {
+            "Greenwich Mean Time", "Coordinated Universal Time", "Eastern European Time",
+            "Central European Time", "Western European Time", "Eastern European Summer Time",
+            "Central European Summer Time", "Western European Summer Time", "Unknown Time Zone"
+        };
+        switch(format) {
+        default:
+        case UPPERCASE_NAME:
+            return uppercase_names[(int)value];
+        case SHORT_NAME:
+            return short_names[(int)value];
+        case FULL_NAME:
+            return full_names[(int)value];
+        }
+        return "";
+    }
+
+
+    /// Enumeration of the moon phases.
+    enum MoonPhase {
+        WAXING_CRESCENT, ///< Waxing Crescent Moon
+        FIRST_QUARTER,   ///< First Quarter Moon
+        WAXING_GIBBOUS,  ///< Waxing Gibbous Moon
+        FULL_MOON,       ///< Full Moon
+        WANING_GIBBOUS,  ///< Waning Gibbous Moon
+        LAST_QUARTER,    ///< Last Quarter Moon
+        WANING_CRESCENT, ///< Waning Crescent Moon
+        NEW_MOON         ///< New Moon
+    };
+
+    /// Enumeration of time format types.
+    enum TimeFormatType {
+        ISO8601_WITH_TZ,      ///< ISO8601 format with time zone (e.g., "2024-06-06T12:30:45+03:00")
+        ISO8601_NO_TZ,        ///< ISO8601 format without time zone (e.g., "2024-06-06T12:30:45")
+        MQL5_FULL,            ///< MQL5 time format (e.g., "2024.06.06 12:30:45")
+        MQL5_DATE_ONLY,       ///< MQL5 date format (e.g., "2024.06.06")
+        MQL5_TIME_ONLY,       ///< MQL5 time format (e.g., "12:30:45")
+        AMERICAN_MONTH_DAY,   ///< American date format (e.g., "06/06/2024")
+        EUROPEAN_MONTH_DAY,   ///< European date format (e.g., "06.06.2024")
+        AMERICAN_TIME,        ///< American time format (e.g., "12:30 PM")
+        EUROPEAN_TIME         ///< European time format (e.g., "12:30")
+    };
+
+    /// \}
+
+}; // namespace time_shield
+
+#endif // __TIME_SHIELD_ENUMS_MQH__

--- a/MQL5/Include/time_shield/time_struct.mqh
+++ b/MQL5/Include/time_shield/time_struct.mqh
@@ -1,0 +1,55 @@
+//+------------------------------------------------------------------+
+//|                                                time_struct.mqh   |
+//|                        Time Shield - MQL5 Time Structure         |
+//|                                      Copyright 2025, NewYaroslav |
+//|                   https://github.com/NewYaroslav/time-shield-cpp |
+//+------------------------------------------------------------------+
+#ifndef __TIME_SHIELD_TIME_STRUCT_MQH__
+#define __TIME_SHIELD_TIME_STRUCT_MQH__
+
+/// \file time_struct.mqh
+/// \ingroup mql5
+/// \brief Header for time structure and related functions (MQL5).
+///
+/// This file contains the definition of the `TimeStruct` structure and a
+/// function to create `TimeStruct` instances for working with time values
+/// in MQL5.
+
+#property copyright "Copyright 2025, NewYaroslav"
+#property link      "https://github.com/NewYaroslav/time-shield-cpp"
+#property strict
+
+namespace time_shield {
+
+    /// \ingroup time_structures
+    /// \brief Structure to represent time in MQL5.
+    struct TimeStruct {
+       int hour;   ///< Hour component of time (0-23).
+       int min;    ///< Minute component of time (0-59).
+       int sec;    ///< Second component of time (0-59).
+       int ms;     ///< Millisecond component of time (0-999).
+    };
+
+    /// \ingroup time_structures
+    /// \brief Creates a `TimeStruct` instance.
+    /// \param hour The hour component of the time.
+    /// \param min The minute component of the time.
+    /// \param sec The second component of the time, defaults to 0.
+    /// \param ms The millisecond component of the time, defaults to 0.
+    /// \return A `TimeStruct` instance with the provided time components.
+    TimeStruct create_time_struct(
+            const int hour,
+            const int min,
+            const int sec = 0,
+            const int ms  = 0) {
+       TimeStruct result;
+       result.hour = hour;
+       result.min  = min;
+       result.sec  = sec;
+       result.ms   = ms;
+       return result;
+    }
+
+}; // namespace time_shield
+
+#endif // __TIME_SHIELD_TIME_STRUCT_MQH__

--- a/MQL5/Include/time_shield/time_zone_struct.mqh
+++ b/MQL5/Include/time_shield/time_zone_struct.mqh
@@ -1,0 +1,134 @@
+//+------------------------------------------------------------------+
+//|                                            time_zone_struct.mqh  |
+//|                      Time Shield - MQL5 Time Zone Structure      |
+//|                                      Copyright 2025, NewYaroslav |
+//|                   https://github.com/NewYaroslav/time-shield-cpp |
+//+------------------------------------------------------------------+
+#ifndef __TIME_SHIELD_TIME_ZONE_STRUCT_MQH__
+#define __TIME_SHIELD_TIME_ZONE_STRUCT_MQH__
+
+/// \file time_zone_struct.mqh
+/// \ingroup mql5
+/// \brief Header for time zone structure and related functions (MQL5).
+///
+/// This file contains the definition of the `TimeZoneStruct` structure and
+/// helper functions to create and convert time zone values in MQL5.
+
+#property copyright "Copyright 2025, NewYaroslav"
+#property link      "https://github.com/NewYaroslav/time-shield-cpp"
+#property strict
+
+namespace time_shield {
+
+    /// \ingroup time_structures
+    /// \brief Structure to represent a time zone offset in MQL5.
+    struct TimeZoneStruct {
+       int  hour;        ///< Hour component of the offset (0-23)
+       int  min;         ///< Minute component of the offset (0-59)
+       bool is_positive; ///< True if the offset is positive, false if negative
+    };
+
+    /// \ingroup time_structures
+    /// \brief Creates a `TimeZoneStruct` instance.
+    /// \param hour The hour component of the offset.
+    /// \param min The minute component of the offset.
+    /// \param is_positive True if the offset is positive, false if negative.
+    /// \return A `TimeZoneStruct` instance with the provided components.
+    TimeZoneStruct create_time_zone_struct(
+            const int  hour,
+            const int  min,
+            const bool is_positive = true) {
+       TimeZoneStruct result;
+       result.hour        = hour;
+       result.min         = min;
+       result.is_positive = is_positive;
+       return result;
+    }
+
+    //----------------------------------------------------------------------
+
+    /// \ingroup time_structures
+    /// \ingroup time_conversions
+    /// \brief Converts an integer offset to a `TimeZoneStruct`.
+    /// \param offset The integer offset in seconds to convert.
+    /// \return A `TimeZoneStruct` represented by the given offset.
+    TimeZoneStruct to_time_zone_struct(const int offset) {
+       int abs_val      = (int)MathAbs(offset);
+       int hour         = abs_val / SEC_PER_HOUR;
+       int min          = abs_val % SEC_PER_MIN;
+       bool is_positive = (offset >= 0);
+       return create_time_zone_struct(hour, min, is_positive);
+    }
+
+    /// \ingroup time_structures
+    /// \ingroup time_conversions
+    /// \brief Alias for `to_time_zone_struct`.
+    /// \copydoc to_time_zone_struct
+    TimeZoneStruct to_tz(const int offset) {
+       return to_time_zone_struct(offset);
+    }
+
+    //----------------------------------------------------------------------
+
+    /// \ingroup time_structures
+    /// \ingroup time_formatting
+    /// \brief Converts a `TimeZoneStruct` to a string representation.
+    /// \param tz The `TimeZoneStruct` to convert.
+    /// \return A string representation like "+03:00" or "-05:30".
+    string time_zone_struct_to_string(const TimeZoneStruct &tz) {
+       string result = tz.is_positive ? "+" : "-";
+       if (tz.hour < 10)
+          result += "0";
+       result += IntegerToString(tz.hour);
+       result += ":";
+       if (tz.min < 10)
+          result += "0";
+       result += IntegerToString(tz.min);
+       return result;
+    }
+
+    /// \ingroup time_structures
+    /// \ingroup time_formatting
+    /// \brief Alias for `time_zone_struct_to_string`.
+    /// \copydoc time_zone_struct_to_string
+    string to_string(const TimeZoneStruct &tz) {
+       return time_zone_struct_to_string(tz);
+    }
+
+    /// \ingroup time_structures
+    /// \ingroup time_formatting
+    /// \brief Alias for `time_zone_struct_to_string`.
+    /// \copydoc time_zone_struct_to_string
+    string to_str(const TimeZoneStruct &tz) {
+       return time_zone_struct_to_string(tz);
+    }
+
+    //----------------------------------------------------------------------
+
+    /// \ingroup time_structures
+    /// \ingroup time_conversions
+    /// \brief Converts a `TimeZoneStruct` to a single integer offset.
+    /// \param tz The `TimeZoneStruct` to convert.
+    /// \return An integer representing the offset in seconds.
+    int time_zone_struct_to_offset(const TimeZoneStruct &tz) {
+       int sign = tz.is_positive ? 1 : -1;
+       return sign * (tz.hour * SEC_PER_HOUR + tz.min * SEC_PER_MIN);
+    }
+
+    /// \ingroup time_conversions
+    /// \brief Alias for `time_zone_struct_to_offset`.
+    /// \copydoc time_zone_struct_to_offset
+    int tz_to_offset(const TimeZoneStruct &tz) {
+       return time_zone_struct_to_offset(tz);
+    }
+
+    /// \ingroup time_conversions
+    /// \brief Alias for `time_zone_struct_to_offset`.
+    /// \copydoc time_zone_struct_to_offset
+    int to_offset(const TimeZoneStruct &tz) {
+       return time_zone_struct_to_offset(tz);
+    }
+
+}; // namespace time_shield
+
+#endif // __TIME_SHIELD_TIME_ZONE_STRUCT_MQH__


### PR DESCRIPTION
## Summary
- implement `time_zone_struct.mqh` providing time zone helpers for MQL5

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68568bd2cc90832c9eccbd9fd21c8d6d