### PR TITLE
feat(mql5): port ISO8601 parser

### DIFF
--- a/MQL5/Include/time_shield/time_conversions.mqh
+++ b/MQL5/Include/time_shield/time_conversions.mqh
@@ -22,6 +22,9 @@
 
 #include <time_shield/constants.mqh>
 #include <time_shield/date_time_struct.mqh>
+#include <time_shield/enums.mqh>
+#include <time_shield/validation.mqh>
+#include <time_shield/time_zone_struct.mqh>
 
 namespace time_shield {
 
@@ -173,9 +176,21 @@ namespace time_shield {
     /// \brief Convert seconds to floating-point hours.
     /// \param sec Seconds value.
     /// \return Hours as double.
-    double sec_to_fhour(long sec) {
+double sec_to_fhour(long sec) {
        return (double)sec / (double)SEC_PER_HOUR;
+   }
+
+    /// \brief Convert a 24-hour format hour to a 12-hour format.
+    /// \param hour Hour value in 24-hour format.
+    /// \return Hour value in 12-hour format.
+    int hour24_to_12(int hour) {
+       if(hour == 0 || hour > 12) return 12;
+       return hour;
     }
+
+    /// \brief Alias for hour24_to_12.
+    /// \copydoc hour24_to_12
+    int h24_to_h12(int hour) { return hour24_to_12(hour); }
 
     //----------------------------------------------------------------------
     // Timestamp <-> Year
@@ -219,6 +234,36 @@ namespace time_shield {
     /// \copydoc get_unix_year
     long to_unix_year(long ts) { return get_unix_year(ts); }
 
+    /// \brief Get the year from a timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Year of the given timestamp.
+    long get_year(long ts) {
+       return get_unix_year(ts) + UNIX_EPOCH;
+    }
+
+    /// \brief Alias for get_year.
+    /// \copydoc get_year
+    long year(long ts) { return get_year(ts); }
+
+    /// \brief Alias for get_year.
+    /// \copydoc get_year
+    long to_year(long ts) { return get_year(ts); }
+
+    /// \brief Get the year from a millisecond timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Year of the given timestamp.
+    long get_year_ms(long ts_ms) {
+       return get_year(ms_to_sec(ts_ms));
+    }
+
+    /// \brief Alias for get_year_ms.
+    /// \copydoc get_year_ms
+    long year_ms(long ts_ms) { return get_year_ms(ts_ms); }
+
+    /// \brief Alias for get_year_ms.
+    /// \copydoc get_year_ms
+    long to_year_ms(long ts_ms) { return get_year_ms(ts_ms); }
+
     //----------------------------------------------------------------------
     // DateTime conversions
     //----------------------------------------------------------------------
@@ -244,6 +289,32 @@ namespace time_shield {
     /// \copydoc to_date_time
     DateTimeStruct to_dt(long ts) { return to_date_time(ts); }
 
+    /// \brief Convert a timestamp to the standard MqlDateTime structure.
+    /// \param ts Timestamp in seconds since UNIX epoch.
+    /// \return Filled MqlDateTime structure.
+    MqlDateTime to_date_time_mql(long ts) {
+       MqlDateTime dt;
+       TimeToStruct((datetime)ts, dt);
+       return dt;
+    }
+
+    /// \brief Alias for to_date_time_mql.
+    /// \copydoc to_date_time_mql
+    MqlDateTime to_mql_dt(long ts) { return to_date_time_mql(ts); }
+
+    /// \brief Convert a timestamp in milliseconds to DateTimeStruct.
+    /// \param ts_ms Timestamp in milliseconds since UNIX epoch.
+    /// \return Filled DateTimeStruct with millisecond part.
+    DateTimeStruct to_date_time_ms(long ts_ms) {
+       DateTimeStruct dt = to_date_time(ms_to_sec(ts_ms));
+       dt.ms = ms_of_ts(ts_ms);
+       return dt;
+    }
+
+    /// \brief Alias for to_date_time_ms.
+    /// \copydoc to_date_time_ms
+    DateTimeStruct to_dt_ms(long ts_ms) { return to_date_time_ms(ts_ms); }
+
     /// \brief Convert a DateTimeStruct to timestamp.
     /// \param dt Structure with date and time fields.
     /// \return Timestamp in seconds.
@@ -258,9 +329,114 @@ namespace time_shield {
        return (long)StructToTime(tmp);
     }
 
+    /// \brief Convert an MqlDateTime structure to timestamp.
+    /// \param dt Standard MqlDateTime structure.
+    /// \return Timestamp in seconds.
+    long dt_to_timestamp(const MqlDateTime &dt) {
+       return (long)StructToTime(dt);
+    }
+
     /// \brief Alias for dt_to_timestamp.
     /// \copydoc dt_to_timestamp
     long to_timestamp(const DateTimeStruct &dt) { return dt_to_timestamp(dt); }
+
+    /// \brief Alias for dt_to_timestamp taking MqlDateTime.
+    /// \copydoc dt_to_timestamp
+    long to_timestamp(const MqlDateTime &dt) { return dt_to_timestamp(dt); }
+
+    /// \brief Convert date and time values to a timestamp.
+    /// \param year Year value.
+    /// \param mon  Month value.
+    /// \param day  Day value.
+    /// \param hour Hour value.
+    /// \param min  Minute value.
+    /// \param sec  Second value.
+    /// \return Timestamp in seconds.
+    long to_timestamp(long year, int mon, int day, int hour=0, int min=0, int sec=0) {
+       MqlDateTime dt;
+       dt.year = (int)year;
+       dt.mon  = mon;
+       dt.day  = day;
+       dt.hour = hour;
+       dt.min  = min;
+       dt.sec  = sec;
+       return (long)StructToTime(dt);
+    }
+
+    /// \brief Alias for to_timestamp with explicit date fields.
+    /// \copydoc to_timestamp
+    long to_ts(long year, int mon, int day, int hour=0, int min=0, int sec=0) {
+       return to_timestamp(year, mon, day, hour, min, sec);
+    }
+
+    /// \brief Convert date and time values to a timestamp in milliseconds.
+    /// \param year Year value.
+    /// \param mon  Month value.
+    /// \param day  Day value.
+    /// \param hour Hour value.
+    /// \param min  Minute value.
+    /// \param sec  Second value.
+    /// \param ms   Millisecond value.
+    /// \return Timestamp in milliseconds.
+    long to_timestamp_ms(long year, int mon, int day, int hour=0, int min=0, int sec=0, int ms=0) {
+       return sec_to_ms(to_timestamp(year, mon, day, hour, min, sec)) + ms;
+    }
+
+    /// \brief Alias for to_timestamp_ms.
+    /// \copydoc to_timestamp_ms
+    long to_ts_ms(long year, int mon, int day, int hour=0, int min=0, int sec=0, int ms=0) {
+       return to_timestamp_ms(year, mon, day, hour, min, sec, ms);
+    }
+
+    /// \brief Alias for to_timestamp_ms.
+    /// \copydoc to_timestamp_ms
+    long ts_ms(long year, int mon, int day, int hour=0, int min=0, int sec=0, int ms=0) {
+       return to_timestamp_ms(year, mon, day, hour, min, sec, ms);
+    }
+
+    /// \brief Convert a DateTimeStruct to a timestamp in milliseconds.
+    /// \param dt Structure with date and time fields.
+    /// \return Timestamp in milliseconds.
+    long dt_to_timestamp_ms(const DateTimeStruct &dt) {
+       return sec_to_ms(dt_to_timestamp(dt)) + dt.ms;
+    }
+
+    /// \brief Convert an MqlDateTime structure to a timestamp in milliseconds.
+    /// \param dt Standard MqlDateTime structure.
+    /// \return Timestamp in milliseconds.
+    long dt_to_timestamp_ms(const MqlDateTime &dt) {
+       return sec_to_ms(dt_to_timestamp(dt));
+    }
+
+    /// \brief Alias for dt_to_timestamp_ms.
+    /// \copydoc dt_to_timestamp_ms
+    long to_timestamp_ms(const DateTimeStruct &dt) { return dt_to_timestamp_ms(dt); }
+
+    /// \brief Alias for dt_to_timestamp_ms.
+    /// \copydoc dt_to_timestamp_ms
+    long to_timestamp_ms(const MqlDateTime &dt) { return dt_to_timestamp_ms(dt); }
+
+    /// \brief Convert a DateTimeStruct to floating-point timestamp.
+    /// \param dt Structure with date and time fields.
+    /// \return Floating-point timestamp.
+    double dt_to_ftimestamp(const DateTimeStruct &dt) {
+       return (double)dt_to_timestamp(dt) + (double)dt.ms / (double)MS_PER_SEC;
+    }
+
+    /// \brief Convert an MqlDateTime structure to floating-point timestamp.
+    /// \param dt Standard MqlDateTime structure.
+    /// \return Floating-point timestamp.
+    double dt_to_ftimestamp(const MqlDateTime &dt) {
+       return (double)dt_to_timestamp(dt);
+    }
+
+    /// \brief Alias for dt_to_ftimestamp.
+    /// \copydoc dt_to_ftimestamp
+    double to_ftimestamp(const DateTimeStruct &dt) { return dt_to_ftimestamp(dt); }
+
+    /// \brief Alias for dt_to_ftimestamp.
+    /// \copydoc dt_to_ftimestamp
+    double to_ftimestamp(const MqlDateTime &dt) { return dt_to_ftimestamp(dt); }
 
     //----------------------------------------------------------------------
     // Start/End of intervals
@@ -273,12 +449,189 @@ namespace time_shield {
        return ts - (ts % SEC_PER_DAY);
     }
 
+    /// \brief Alias for start_of_day.
+    /// \copydoc start_of_day
+    long day_start(long ts) { return start_of_day(ts); }
+
+    /// \brief Get the start of the previous day.
+    /// \param ts   Timestamp in seconds.
+    /// \param days Number of days to go back (default 1).
+    /// \return Timestamp at 00:00:00 of the previous day.
+    long start_of_prev_day(long ts, int days=1) {
+       return start_of_day(ts) - days * SEC_PER_DAY;
+    }
+
+    /// \brief Alias for start_of_prev_day.
+    /// \copydoc start_of_prev_day
+    long previous_day_start(long ts, int days=1) { return start_of_prev_day(ts, days); }
+
+    /// \brief Get the start of the day in seconds from milliseconds timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at 00:00:00 of the same day in seconds.
+    long start_of_day_sec(long ts_ms) {
+       return start_of_day(ms_to_sec(ts_ms));
+    }
+
+    /// \brief Alias for start_of_day_sec.
+    /// \copydoc start_of_day_sec
+    long day_start_sec(long ts_ms) { return start_of_day_sec(ts_ms); }
+
+    /// \brief Get the start of the day for a millisecond timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at 00:00:00.000 of the same day.
+    long start_of_day_ms(long ts_ms) {
+       return ts_ms - (ts_ms % MS_PER_DAY);
+    }
+
+    /// \brief Alias for start_of_day_ms.
+    /// \copydoc start_of_day_ms
+    long day_start_ms(long ts_ms) { return start_of_day_ms(ts_ms); }
+
+    /// \brief Get the start of the next day.
+    /// \param ts   Timestamp in seconds.
+    /// \param days Number of days ahead (default 1).
+    /// \return Timestamp at 00:00:00 of the next day.
+    long start_of_next_day(long ts, int days=1) {
+       return start_of_day(ts) + days * SEC_PER_DAY;
+    }
+
+    /// \brief Alias for start_of_next_day.
+    /// \copydoc start_of_next_day
+    long next_day_start(long ts, int days=1) { return start_of_next_day(ts, days); }
+
+    /// \brief Get the start of the next day in milliseconds.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \param days  Number of days ahead (default 1).
+    /// \return Timestamp at 00:00:00.000 of the next day in milliseconds.
+    long start_of_next_day_ms(long ts_ms, int days=1) {
+       return start_of_day_ms(ts_ms) + days * MS_PER_DAY;
+    }
+
+    /// \brief Alias for start_of_next_day_ms.
+    /// \copydoc start_of_next_day_ms
+    long next_day_start_ms(long ts_ms, int days=1) { return start_of_next_day_ms(ts_ms, days); }
+
+    /// \brief Add days to a timestamp without adjusting to start of day.
+    /// \param ts   Timestamp in seconds.
+    /// \param days Number of days to add (default 1).
+    /// \return Timestamp shifted forward by the given days.
+    long next_day(long ts, int days=1) {
+       return ts + days * SEC_PER_DAY;
+    }
+
+    /// \brief Add days to a millisecond timestamp without adjusting to start of day.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \param days  Number of days to add (default 1).
+    /// \return Timestamp shifted forward by the given days in milliseconds.
+    long next_day_ms(long ts_ms, int days=1) {
+       return ts_ms + days * MS_PER_DAY;
+    }
+
     /// \brief Get the end of the day for a timestamp.
     /// \param ts Timestamp in seconds.
     /// \return Timestamp at 23:59:59 of the same day.
     long end_of_day(long ts) {
        return ts - (ts % SEC_PER_DAY) + SEC_PER_DAY - 1;
     }
+
+    /// \brief Alias for end_of_day.
+    /// \copydoc end_of_day
+    long day_end(long ts) { return end_of_day(ts); }
+
+    /// \brief Get the end of the day in seconds from milliseconds timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at 23:59:59 of the same day in seconds.
+    long end_of_day_sec(long ts_ms) {
+       return end_of_day(ms_to_sec(ts_ms));
+    }
+
+    /// \brief Alias for end_of_day_sec.
+    /// \copydoc end_of_day_sec
+    long day_end_sec(long ts_ms) { return end_of_day_sec(ts_ms); }
+
+    /// \brief Get the end of the day for a millisecond timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at 23:59:59.999 of the same day.
+    long end_of_day_ms(long ts_ms) {
+       return ts_ms - (ts_ms % MS_PER_DAY) + MS_PER_DAY - 1;
+    }
+
+    /// \brief Alias for end_of_day_ms.
+    /// \copydoc end_of_day_ms
+    long day_end_ms(long ts_ms) { return end_of_day_ms(ts_ms); }
+
+    /// \brief Get the day of the week for a date.
+    /// \param year  Year value.
+    /// \param month Month value.
+    /// \param day   Day of the month.
+    /// \return Weekday (SUN=0, MON=1, ... SAT=6).
+    int day_of_week_date(long year, int month, int day) {
+       long a = (14 - month) / MONTHS_PER_YEAR;
+       long y = year - a;
+       long m = month + MONTHS_PER_YEAR * a - 2;
+       long r = 7000 + day + y + (y / 4) - (y / 100) + (y / 400) + (31 * m) / MONTHS_PER_YEAR;
+       return (int)(r % DAYS_PER_WEEK);
+    }
+
+    /// \brief Alias for day_of_week_date.
+    /// \copydoc day_of_week_date
+    int get_weekday(long year, int month, int day) { return day_of_week_date(year, month, day); }
+
+    /// \brief Alias for day_of_week_date.
+    /// \copydoc day_of_week_date
+    int day_of_week(long year, int month, int day) { return day_of_week_date(year, month, day); }
+
+    /// \brief Get weekday from a DateTimeStruct.
+    /// \param dt Date structure with fields year, mon, day.
+    /// \return Weekday (SUN=0, MON=1, ... SAT=6).
+    int get_weekday_from_date(const DateTimeStruct &dt) {
+       return day_of_week_date(dt.year, dt.mon, dt.day);
+    }
+
+    /// \brief Get weekday from a MqlDateTime structure.
+    /// \param dt Standard MqlDateTime structure.
+    /// \return Weekday (SUN=0, MON=1, ... SAT=6).
+    int get_weekday_from_date(const MqlDateTime &dt) {
+       return day_of_week_date(dt.year, dt.mon, dt.day);
+    }
+
+    /// \brief Alias for get_weekday_from_date with DateTimeStruct.
+    /// \copydoc get_weekday_from_date(const DateTimeStruct&)
+    int day_of_week_dt(const DateTimeStruct &dt) { return get_weekday_from_date(dt); }
+
+    /// \brief Alias for get_weekday_from_date with DateTimeStruct.
+    /// \copydoc get_weekday_from_date(const DateTimeStruct&)
+    int day_of_week(const DateTimeStruct &dt) { return get_weekday_from_date(dt); }
+
+    /// \brief Alias for get_weekday_from_date with MqlDateTime.
+    /// \copydoc get_weekday_from_date(const MqlDateTime&)
+    int day_of_week_dt(const MqlDateTime &dt) { return get_weekday_from_date(dt); }
+
+    /// \brief Alias for get_weekday_from_date with MqlDateTime.
+    /// \copydoc get_weekday_from_date(const MqlDateTime&)
+    int day_of_week(const MqlDateTime &dt) { return get_weekday_from_date(dt); }
+
+    /// \brief Get weekday from timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Weekday (SUN=0, MON=1, ... SAT=6).
+    int get_weekday_from_ts(long ts) {
+       return (int)((ts / SEC_PER_DAY + THU) % DAYS_PER_WEEK);
+    }
+
+    /// \brief Alias for get_weekday_from_ts.
+    /// \copydoc get_weekday_from_ts
+    int day_of_week(long ts) { return get_weekday_from_ts(ts); }
+
+    /// \brief Get weekday from millisecond timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Weekday (SUN=0, MON=1, ... SAT=6).
+    int get_weekday_from_ts_ms(long ts_ms) {
+       return get_weekday_from_ts(ms_to_sec(ts_ms));
+    }
+
+    /// \brief Alias for get_weekday_from_ts_ms.
+    /// \copydoc get_weekday_from_ts_ms
+    int day_of_week_ms(long ts_ms) { return get_weekday_from_ts_ms(ts_ms); }
 
     /// \brief Get the start of the year for a timestamp.
     /// \param ts Timestamp in seconds.
@@ -298,6 +651,401 @@ namespace time_shield {
        return (long)StructToTime(dt) - 1;
     }
 
+    /// \brief Alias for start_of_year.
+    /// \copydoc start_of_year
+    long year_start(long ts) { return start_of_year(ts); }
+
+    /// \brief Alias for start_of_year.
+    /// \copydoc start_of_year
+    long year_begin(long ts) { return start_of_year(ts); }
+
+    /// \brief Get the start of the year in milliseconds.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at 00:00:00 on January 1st in milliseconds.
+    long start_of_year_ms(long ts_ms) {
+       return sec_to_ms(start_of_year(ms_to_sec(ts_ms)));
+    }
+
+    /// \brief Alias for start_of_year_ms.
+    /// \copydoc start_of_year_ms
+    long year_start_ms(long ts_ms) { return start_of_year_ms(ts_ms); }
+
+    /// \brief Alias for start_of_year_ms.
+    /// \copydoc start_of_year_ms
+    long year_begin_ms(long ts_ms) { return start_of_year_ms(ts_ms); }
+
+    /// \brief Get the timestamp for the start of the specified year.
+    /// \param year Year value.
+    /// \return Timestamp at 00:00:00 on January 1st of the given year.
+    long start_of_year_date(long year) {
+       if(year < 2100) {
+          long year_diff      = year >= UNIX_EPOCH ? year - UNIX_EPOCH : UNIX_EPOCH - year;
+          long year_start_ts  = (year_diff / 4) * SEC_PER_4_YEARS;
+          long year_remainder = year_diff % 4;
+          long SEC_PER_YEAR_X2 = 2 * SEC_PER_YEAR;
+          long SEC_PER_YEAR_V2 = SEC_PER_YEAR_X2 + SEC_PER_LEAP_YEAR;
+          switch(year_remainder) {
+             case 0: return year_start_ts;
+             case 1: return year_start_ts + SEC_PER_YEAR;
+             case 2: return year_start_ts + SEC_PER_YEAR_X2;
+             default: return year_start_ts + SEC_PER_YEAR_V2;
+          }
+          return year_start_ts + SEC_PER_YEAR_V2;
+       }
+       return to_timestamp(year, 1, 1);
+    }
+
+    /// \brief Alias for start_of_year_date.
+    /// \copydoc start_of_year_date
+    long year_start_date(long year) { return start_of_year_date(year); }
+
+    /// \brief Alias for start_of_year_date.
+    /// \copydoc start_of_year_date
+    long year_begin_date(long year) { return start_of_year_date(year); }
+
+    /// \brief Get the timestamp in milliseconds for the start of the specified year.
+    /// \param year Year value.
+    /// \return Timestamp at 00:00:00 on January 1st in milliseconds.
+    long start_of_year_date_ms(long year) {
+       return sec_to_ms(start_of_year_date(year));
+    }
+
+    /// \brief Alias for start_of_year_date_ms.
+    /// \copydoc start_of_year_date_ms
+    long year_start_date_ms(long year) { return start_of_year_date_ms(year); }
+
+    /// \brief Alias for start_of_year_date_ms.
+    /// \copydoc start_of_year_date_ms
+    long year_begin_date_ms(long year) { return start_of_year_date_ms(year); }
+
+    /// \brief Get the end of the year in milliseconds.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp of 23:59:59.999 on December 31st of the year.
+    long end_of_year_ms(long ts_ms) {
+       return sec_to_ms(end_of_year(ms_to_sec(ts_ms)));
+    }
+
+    /// \brief Alias for end_of_year_ms.
+    /// \copydoc end_of_year_ms
+    long year_end_ms(long ts_ms) { return end_of_year_ms(ts_ms); }
+
+    /// \brief Get the day of the year.
+    /// \param ts Timestamp in seconds.
+    /// \return Day of the year (1-366).
+    int day_of_year(long ts) {
+       return (int)((ts - start_of_year(ts)) / SEC_PER_DAY) + 1;
+    }
+
+    /// \brief Get the month of the year.
+    /// \param ts Timestamp in seconds.
+    /// \return Month of the year.
+    Month month_of_year(long ts) {
+       const int JAN_AND_FEB_DAY_LEAP_YEAR = 60;
+       static const int TABLE_MONTH_OF_YEAR[] = {
+           0,
+           1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+           2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
+           3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,
+           4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,4,
+           5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
+           6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
+           7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
+           8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+           9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+           10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,10,
+           11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,11,
+           12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,12,
+       };
+       int dy = day_of_year(ts);
+       if(is_leap_year(ts) && dy >= JAN_AND_FEB_DAY_LEAP_YEAR)
+          return (Month)TABLE_MONTH_OF_YEAR[dy - 1];
+       return (Month)TABLE_MONTH_OF_YEAR[dy];
+    }
+
+    /// \brief Get the day of the month.
+    /// \param ts Timestamp in seconds.
+    /// \return Day of the month.
+    int day_of_month(long ts) {
+       const int JAN_AND_FEB_DAY_LEAP_YEAR = 60;
+       static const int TABLE_DAY_OF_YEAR[] = {
+           0,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,
+           1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,
+       };
+       int dy = day_of_year(ts);
+       if(is_leap_year(ts)) {
+          if(dy == JAN_AND_FEB_DAY_LEAP_YEAR) return TABLE_DAY_OF_YEAR[dy - 1] + 1;
+          if(dy > JAN_AND_FEB_DAY_LEAP_YEAR) return TABLE_DAY_OF_YEAR[dy - 1];
+       }
+       return TABLE_DAY_OF_YEAR[dy];
+    }
+
+    /// \brief Get the number of days in a month.
+    /// \param year Year value.
+    /// \param month Month value.
+    /// \return Number of days in the month.
+    int num_days_in_month(long year, int month) {
+       if(month > MONTHS_PER_YEAR || month < 0) return 0;
+       static const int num_days[13] = {0,31,30,31,30,31,30,31,31,30,31,30,31};
+       if(month == FEB) {
+          if(is_leap_year_date(year)) return 29;
+          return 28;
+       }
+       return num_days[month];
+    }
+
+    /// \brief Alias for num_days_in_month.
+    /// \copydoc num_days_in_month
+    int days_in_month(long year, int month) { return num_days_in_month(year, month); }
+
+    /// \brief Get the number of days in the month of a timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Number of days in that month.
+    int num_days_in_month_ts(long ts) {
+       static const int num_days[13] = {0,31,28,31,30,31,30,31,31,30,31,30,31};
+       int month = month_of_year(ts);
+       if(month == FEB) {
+          return is_leap_year(ts) ? 29 : 28;
+       }
+       return num_days[month];
+    }
+
+    /// \brief Alias for num_days_in_month_ts.
+    /// \copydoc num_days_in_month_ts
+    int num_days_in_month(long ts) { return num_days_in_month_ts(ts); }
+
+    /// \brief Alias for num_days_in_month_ts.
+    /// \copydoc num_days_in_month_ts
+    int days_in_month(long ts) { return num_days_in_month_ts(ts); }
+
+    /// \brief Get number of days in a year.
+    /// \param year Year value.
+    /// \return Days in the year.
+    int num_days_in_year(long year) {
+       if(is_leap_year_date(year)) return DAYS_PER_LEAP_YEAR;
+       return DAYS_PER_YEAR;
+    }
+
+    /// \brief Alias for num_days_in_year.
+    /// \copydoc num_days_in_year
+    int days_in_year(long year) { return num_days_in_year(year); }
+
+    /// \brief Get number of days in the year of the timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Days in the year of the timestamp.
+    int num_days_in_year_ts(long ts) {
+       if(is_leap_year_ts(ts)) return DAYS_PER_LEAP_YEAR;
+       return DAYS_PER_YEAR;
+    }
+
+    /// \brief Alias for num_days_in_year_ts.
+    /// \copydoc num_days_in_year_ts
+    int days_in_year_ts(long ts) { return num_days_in_year_ts(ts); }
+
+    /// \brief Get the timestamp at the start of the month.
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at 00:00:00 on the first day of the month.
+    long start_of_month(long ts) {
+       return start_of_day(ts) - (day_of_month(ts) - 1) * SEC_PER_DAY;
+    }
+
+    /// \brief Alias for start_of_month.
+    /// \copydoc start_of_month
+    long month_begin(long ts) { return start_of_month(ts); }
+
+    /// \brief Get the timestamp at the end of the month.
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at 23:59:59 on the last day of the month.
+    long end_of_month(long ts) {
+       return end_of_day(ts) + (num_days_in_month(ts) - day_of_month(ts)) * SEC_PER_DAY;
+    }
+
+    /// \brief Alias for end_of_month.
+    /// \copydoc end_of_month
+    long last_day_of_month(long ts) { return end_of_month(ts); }
+
+    /// \brief Get the timestamp of the last Sunday of the month.
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at 00:00:00 of the last Sunday of the month.
+    long last_sunday_of_month(long ts) {
+       return end_of_month(ts) - day_of_week(ts) * SEC_PER_DAY;
+    }
+
+    /// \brief Alias for last_sunday_of_month.
+    /// \copydoc last_sunday_of_month
+    long final_sunday_of_month(long ts) { return last_sunday_of_month(ts); }
+
+    /// \brief Get the day of the last Sunday for the given month and year.
+    /// \param year Year value.
+    /// \param month Month value.
+    /// \return Day of the last Sunday of that month.
+    int last_sunday_month_day(long year, int month) {
+       int days = num_days_in_month(year, month);
+       return days - day_of_week_date(year, month, days);
+    }
+
+    /// \brief Alias for last_sunday_month_day.
+    /// \copydoc last_sunday_month_day
+    int final_sunday_month_day(long year, int month) { return last_sunday_month_day(year, month); }
+
+    /// \brief Get the start of the hour for a timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at HH:00:00 of the same hour.
+    long start_of_hour(long ts) {
+       return ts - (ts % SEC_PER_HOUR);
+    }
+
+    /// \brief Alias for start_of_hour.
+    /// \copydoc start_of_hour
+    long hour_begin(long ts) { return start_of_hour(ts); }
+
+    /// \brief Get the start of the hour in seconds from milliseconds timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at HH:00:00 of the hour in seconds.
+    long start_of_hour_sec(long ts_ms) {
+       return start_of_hour(ms_to_sec(ts_ms));
+    }
+
+    /// \brief Alias for start_of_hour_sec.
+    /// \copydoc start_of_hour_sec
+    long hour_begin_sec(long ts_ms) { return start_of_hour_sec(ts_ms); }
+
+    /// \brief Get the start of the hour for a millisecond timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at HH:00:00.000 of the hour.
+    long start_of_hour_ms(long ts_ms) {
+       return ts_ms - (ts_ms % MS_PER_HOUR);
+    }
+
+    /// \brief Alias for start_of_hour_ms.
+    /// \copydoc start_of_hour_ms
+    long hour_begin_ms(long ts_ms) { return start_of_hour_ms(ts_ms); }
+
+    /// \brief Get the end of the hour for a timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at HH:59:59 of the same hour.
+    long end_of_hour(long ts) {
+       return ts - (ts % SEC_PER_HOUR) + SEC_PER_HOUR - 1;
+    }
+
+    /// \brief Alias for end_of_hour.
+    /// \copydoc end_of_hour
+    long finish_of_hour(long ts) { return end_of_hour(ts); }
+
+    /// \brief Get the end of the hour in seconds from milliseconds timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at HH:59:59 of the hour in seconds.
+    long end_of_hour_sec(long ts_ms) {
+       return end_of_hour(ms_to_sec(ts_ms));
+    }
+
+    /// \brief Alias for end_of_hour_sec.
+    /// \copydoc end_of_hour_sec
+    long finish_of_hour_sec(long ts_ms) { return end_of_hour_sec(ts_ms); }
+
+    /// \brief Get the end of the hour for a millisecond timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Timestamp at HH:59:59.999 of the hour.
+    long end_of_hour_ms(long ts_ms) {
+       return ts_ms - (ts_ms % MS_PER_HOUR) + MS_PER_HOUR - 1;
+    }
+
+    /// \brief Alias for end_of_hour_ms.
+    /// \copydoc end_of_hour_ms
+    long finish_of_hour_ms(long ts_ms) { return end_of_hour_ms(ts_ms); }
+
+    /// \brief Get the hour of the day.
+    /// \param ts Timestamp in seconds.
+    /// \return Hour value 0-23.
+    int hour_of_day(long ts) {
+       return (int)((ts / SEC_PER_HOUR) % HOURS_PER_DAY);
+    }
+
+    /// \brief Alias for hour_of_day.
+    /// \copydoc hour_of_day
+    int hour_in_day(long ts) { return hour_of_day(ts); }
+
+    /// \brief Get the start of the week (Sunday).
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at 00:00:00 on Sunday of the current week.
+    long start_of_week(long ts) {
+       return start_of_day(ts) - day_of_week(ts) * SEC_PER_DAY;
+    }
+
+    /// \brief Alias for start_of_week.
+    /// \copydoc start_of_week
+    long week_begin(long ts) { return start_of_week(ts); }
+
+    /// \brief Get the end of the week (Saturday end).
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at 23:59:59 on Saturday of the current week.
+    long end_of_week(long ts) {
+       return start_of_day(ts) + (DAYS_PER_WEEK - day_of_week(ts)) * SEC_PER_DAY - 1;
+    }
+
+    /// \brief Alias for end_of_week.
+    /// \copydoc end_of_week
+    long finish_of_week(long ts) { return end_of_week(ts); }
+
+    /// \brief Get the start of Saturday for the week of the timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at 00:00:00 on Saturday of the current week.
+    long start_of_saturday(long ts) {
+       return start_of_day(ts) + (SAT - day_of_week(ts)) * SEC_PER_DAY;
+    }
+
+    /// \brief Alias for start_of_saturday.
+    /// \copydoc start_of_saturday
+    long saturday_begin(long ts) { return start_of_saturday(ts); }
+
+    /// \brief Get the start of the minute for a timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at mm:00 of the same minute.
+    long start_of_min(long ts) {
+       return ts - (ts % SEC_PER_MIN);
+    }
+
+    /// \brief Alias for start_of_min.
+    /// \copydoc start_of_min
+    long min_begin(long ts) { return start_of_min(ts); }
+
+    /// \brief Get the end of the minute for a timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Timestamp at mm:59 of the same minute.
+    long end_of_min(long ts) {
+       return ts - (ts % SEC_PER_MIN) + SEC_PER_MIN - 1;
+    }
+
+    /// \brief Alias for end_of_min.
+    /// \copydoc end_of_min
+    long finish_of_min(long ts) { return end_of_min(ts); }
+
+    /// \brief Get the minute of the day.
+    /// \param ts Timestamp in seconds.
+    /// \return Minute of the day (0-1439).
+    int min_of_day(long ts) {
+       return (int)((ts / SEC_PER_MIN) % MIN_PER_DAY);
+    }
+
+    /// \brief Get the minute of the hour.
+    /// \param ts Timestamp in seconds.
+    /// \return Minute of the hour (0-59).
+    int min_of_hour(long ts) {
+       return (int)((ts / SEC_PER_MIN) % MIN_PER_HOUR);
+    }
+
+    /// \brief Alias for min_of_hour.
+    /// \copydoc min_of_hour
+    int min_in_hour(long ts) { return min_of_hour(ts); }
+
     /// \brief Get the start of a period.
     /// \param p Period length in seconds.
     /// \param ts Timestamp (default current). Use time_utils.ts().
@@ -313,6 +1061,227 @@ namespace time_shield {
     long end_of_period(int p, long ts) {
        return ts - (ts % p) + p - 1;
     }
+
+    //----------------------------------------------------------------------
+    // UNIX day and minute helpers
+    //----------------------------------------------------------------------
+
+    /// \brief Get UNIX day from timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Number of days since UNIX epoch.
+    long get_unix_day(long ts) {
+       return ts / SEC_PER_DAY;
+    }
+
+    /// \brief Alias for get_unix_day.
+    /// \copydoc get_unix_day
+    long unix_day(long ts) { return get_unix_day(ts); }
+
+    /// \brief Alias for get_unix_day.
+    /// \copydoc get_unix_day
+    long get_unixday(long ts) { return get_unix_day(ts); }
+
+    /// \brief Alias for get_unix_day.
+    /// \copydoc get_unix_day
+    long unixday(long ts) { return get_unix_day(ts); }
+
+    /// \brief Alias for get_unix_day.
+    /// \copydoc get_unix_day
+    long uday(long ts) { return get_unix_day(ts); }
+
+    /// \brief Get number of days between two timestamps.
+    /// \param start Start timestamp in seconds.
+    /// \param stop  End timestamp in seconds.
+    /// \return Difference in days.
+    int get_days_difference(long start, long stop) {
+       return (int)((stop - start) / SEC_PER_DAY);
+    }
+
+    /// \brief Alias for get_days_difference.
+    /// \copydoc get_days_difference
+    int get_days(long start, long stop) { return get_days_difference(start, stop); }
+
+    /// \brief Alias for get_days_difference.
+    /// \copydoc get_days_difference
+    int days(long start, long stop) { return get_days_difference(start, stop); }
+
+    /// \brief Get UNIX day from milliseconds timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Number of days since UNIX epoch.
+    long get_unix_day_ms(long ts_ms) {
+       return get_unix_day(ms_to_sec(ts_ms));
+    }
+
+    /// \brief Alias for get_unix_day_ms.
+    /// \copydoc get_unix_day_ms
+    long unix_day_ms(long ts_ms) { return get_unix_day_ms(ts_ms); }
+
+    /// \brief Alias for get_unix_day_ms.
+    /// \copydoc get_unix_day_ms
+    long get_unixday_ms(long ts_ms) { return get_unix_day_ms(ts_ms); }
+
+    /// \brief Alias for get_unix_day_ms.
+    /// \copydoc get_unix_day_ms
+    long unixday_ms(long ts_ms) { return get_unix_day_ms(ts_ms); }
+
+    /// \brief Alias for get_unix_day_ms.
+    /// \copydoc get_unix_day_ms
+    long uday_ms(long ts_ms) { return get_unix_day_ms(ts_ms); }
+
+    /// \brief Convert UNIX day to timestamp in seconds.
+    /// \param uday UNIX day value.
+    /// \return Timestamp at start of the day.
+    long unix_day_to_timestamp(long uday) {
+       return uday * SEC_PER_DAY;
+    }
+
+    /// \brief Alias for unix_day_to_timestamp.
+    /// \copydoc unix_day_to_timestamp
+    long unix_day_to_ts(long uday) { return unix_day_to_timestamp(uday); }
+
+    /// \brief Alias for unix_day_to_timestamp.
+    /// \copydoc unix_day_to_timestamp
+    long unixday_to_ts(long uday) { return unix_day_to_timestamp(uday); }
+
+    /// \brief Alias for unix_day_to_timestamp.
+    /// \copydoc unix_day_to_timestamp
+    long uday_to_ts(long uday) { return unix_day_to_timestamp(uday); }
+
+    /// \brief Alias for unix_day_to_timestamp.
+    /// \copydoc unix_day_to_timestamp
+    long start_of_day_from_unix_day(long uday) { return unix_day_to_timestamp(uday); }
+
+    /// \brief Convert UNIX day to timestamp in milliseconds.
+    /// \param uday UNIX day value.
+    /// \return Timestamp at start of the day in milliseconds.
+    long unix_day_to_timestamp_ms(long uday) {
+       return uday * MS_PER_DAY;
+    }
+
+    /// \brief Alias for unix_day_to_timestamp_ms.
+    /// \copydoc unix_day_to_timestamp_ms
+    long unix_day_to_ts_ms(long uday) { return unix_day_to_timestamp_ms(uday); }
+
+    /// \brief Alias for unix_day_to_timestamp_ms.
+    /// \copydoc unix_day_to_timestamp_ms
+    long unixday_to_ts_ms(long uday) { return unix_day_to_timestamp_ms(uday); }
+
+    /// \brief Alias for unix_day_to_timestamp_ms.
+    /// \copydoc unix_day_to_timestamp_ms
+    long uday_to_ts_ms(long uday) { return unix_day_to_timestamp_ms(uday); }
+
+    /// \brief Alias for unix_day_to_timestamp_ms.
+    /// \copydoc unix_day_to_timestamp_ms
+    long start_of_day_from_unix_day_ms(long uday) { return unix_day_to_timestamp_ms(uday); }
+
+    /// \brief Get end of day timestamp from UNIX day.
+    /// \param uday UNIX day value.
+    /// \return Timestamp at 23:59:59 of the specified day.
+    long end_of_day_from_unix_day(long uday) {
+       return uday * SEC_PER_DAY + SEC_PER_DAY - 1;
+    }
+
+    /// \brief Get end of day timestamp in ms from UNIX day.
+    /// \param uday UNIX day value.
+    /// \return Timestamp at 23:59:59.999 of the specified day.
+    long end_of_day_from_unix_day_ms(long uday) {
+       return uday * MS_PER_DAY + MS_PER_DAY - 1;
+    }
+
+    /// \brief Alias for end_of_day_from_unix_day.
+    /// \copydoc end_of_day_from_unix_day
+    long eod_from_unix_day(long uday) { return end_of_day_from_unix_day(uday); }
+
+    /// \brief Alias for end_of_day_from_unix_day_ms.
+    /// \copydoc end_of_day_from_unix_day_ms
+    long eod_from_unix_day_ms(long uday) { return end_of_day_from_unix_day_ms(uday); }
+
+    /// \brief Get start of next day timestamp from UNIX day.
+    /// \param uday UNIX day value.
+    /// \return Timestamp at start of next day in seconds.
+    long start_of_next_day_from_unix_day(long uday) {
+       return uday * SEC_PER_DAY + SEC_PER_DAY;
+    }
+
+    /// \brief Get start of next day timestamp in ms from UNIX day.
+    /// \param uday UNIX day value.
+    /// \return Timestamp at start of next day in milliseconds.
+    long start_of_next_day_from_unix_day_ms(long uday) {
+       return uday * MS_PER_DAY + MS_PER_DAY;
+    }
+
+    /// \brief Alias for start_of_next_day_from_unix_day.
+    /// \copydoc start_of_next_day_from_unix_day
+    long next_day_unix_day(long uday) { return start_of_next_day_from_unix_day(uday); }
+
+    /// \brief Alias for start_of_next_day_from_unix_day.
+    /// \copydoc start_of_next_day_from_unix_day
+    long next_day_unixday(long uday) { return start_of_next_day_from_unix_day(uday); }
+
+    /// \brief Alias for start_of_next_day_from_unix_day_ms.
+    /// \copydoc start_of_next_day_from_unix_day_ms
+    long next_day_unix_day_ms(long uday) { return start_of_next_day_from_unix_day_ms(uday); }
+
+    /// \brief Alias for start_of_next_day_from_unix_day_ms.
+    /// \copydoc start_of_next_day_from_unix_day_ms
+    long next_day_unixday_ms(long uday) { return start_of_next_day_from_unix_day_ms(uday); }
+
+    /// \brief Alias for start_of_next_day_from_unix_day.
+    /// \copydoc start_of_next_day_from_unix_day
+    long next_day_from_unix_day(long uday) { return start_of_next_day_from_unix_day(uday); }
+
+    /// \brief Get UNIX minute from timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Minutes since UNIX epoch.
+    long get_unix_min(long ts) {
+       return ts / SEC_PER_MIN;
+    }
+
+    /// \brief Alias for get_unix_min.
+    /// \copydoc get_unix_min
+    long unix_min(long ts) { return get_unix_min(ts); }
+
+    /// \brief Alias for get_unix_min.
+    /// \copydoc get_unix_min
+    long to_unix_min(long ts) { return get_unix_min(ts); }
+
+    /// \brief Alias for get_unix_min.
+    /// \copydoc get_unix_min
+    long umin(long ts) { return get_unix_min(ts); }
+
+    /// \brief Get second of day from timestamp.
+    /// \param ts Timestamp in seconds.
+    /// \return Second of the day.
+    int sec_of_day(long ts) {
+       return (int)(ts % SEC_PER_DAY);
+    }
+
+    /// \brief Get second of day from milliseconds timestamp.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Second of the day.
+    int sec_of_day_ms(long ts_ms) {
+       return sec_of_day(ms_to_sec(ts_ms));
+    }
+
+    /// \brief Get second of day from hours, minutes and seconds.
+    /// \param hour Hour value.
+    /// \param min  Minute value.
+    /// \param sec  Second value.
+    /// \return Second of the day.
+    int sec_of_day(int hour, int min, int sec) {
+       return hour * SEC_PER_HOUR + min * SEC_PER_MIN + sec;
+    }
+
+    /// \brief Convert an integer offset to a TimeZoneStruct.
+    /// \param offset Offset in seconds.
+    /// \return TimeZoneStruct represented by the offset.
+    TimeZoneStruct to_time_zone(int offset) {
+       return to_time_zone_struct(offset);
+    }
+
+    /// \brief Alias for to_time_zone.
+    /// \copydoc to_time_zone
+    TimeZoneStruct to_tz_struct(int offset) { return to_time_zone(offset); }
 
     /// \}
 

--- a/MQL5/Include/time_shield/time_formatting.mqh
+++ b/MQL5/Include/time_shield/time_formatting.mqh
@@ -1,0 +1,487 @@
+//+------------------------------------------------------------------+
+//|                                            time_formatting.mqh   |
+//|                      Time Shield - MQL5 Time Formatting          |
+//|                                      Copyright 2025, NewYaroslav |
+//|                   https://github.com/NewYaroslav/time-shield-cpp |
+//+------------------------------------------------------------------+
+#ifndef __TIME_SHIELD_TIME_FORMATTING_MQH__
+#define __TIME_SHIELD_TIME_FORMATTING_MQH__
+
+/// \file time_formatting.mqh
+/// \ingroup mql5
+/// \brief Header with helper functions for formatting timestamps and
+/// date-time values in MQL5.
+///
+/// This file provides functions for converting timestamps to various
+/// string representations including ISO8601 and MQL5 specific formats.
+
+#property copyright "Copyright 2025, NewYaroslav"
+#property link      "https://github.com/NewYaroslav/time-shield-cpp"
+#property strict
+
+#include <time_shield/date_time_struct.mqh>
+#include <time_shield/time_zone_struct.mqh>
+#include <time_shield/time_conversions.mqh>
+#include <time_shield/enums.mqh>
+
+namespace time_shield {
+
+    /// \defgroup time_formatting Time Formatting
+    /// \brief Utility functions for formatting timestamps.
+    /// \{
+
+   /// \brief Internal helper to pad integer with leading zeros.
+   /// \param value Integer value to pad.
+   /// \param width Desired width of the number.
+   /// \return String with left-padded digits.
+   string pad_int(int value, int width) {
+       string s = IntegerToString(value);
+       while(StringLen(s) < width)
+          s = "0" + s;
+       return s;
+    }
+
+    //----------------------------------------------------------------------
+    // Custom formatting
+    //----------------------------------------------------------------------
+
+   /// \brief Internal helper for custom formatting processing.
+   ///
+   /// This function handles individual format specifiers used by
+   /// \ref to_string and \ref to_string_ms.
+   ///
+   /// \param last_char     Current format character.
+   /// \param repeat_count  Number of repeats of the format character.
+   /// \param ts            Timestamp in seconds.
+   /// \param utc_offset    UTC offset in seconds.
+   /// \param dt            DateTimeStruct corresponding to the timestamp.
+   /// \param result        Output string being built.
+   void process_format_impl(
+           const char last_char,
+           int repeat_count,
+           long ts,
+           int utc_offset,
+           const DateTimeStruct &dt,
+           string &result)
+    {
+       switch(last_char) {
+          case 'a':
+             if(repeat_count<=1)
+                result += to_str(day_of_week(dt.year, dt.mon, dt.day), SHORT_NAME);
+             break;
+          case 'A':
+             if(repeat_count<=1)
+                result += to_str(day_of_week(dt.year, dt.mon, dt.day), FULL_NAME);
+             break;
+          case 'I':
+             if(repeat_count==1)
+                result += pad_int(hour24_to_12(dt.hour),2);
+             break;
+          case 'H':
+             if(repeat_count<=2)
+                result += pad_int(dt.hour,2);
+             break;
+          case 'h':
+             if(repeat_count==2)
+                result += pad_int(dt.hour,2);
+             else
+                result += to_str((Month)dt.mon, SHORT_NAME);
+             break;
+          case 'b':
+             if(repeat_count<=1)
+                result += to_str((Month)dt.mon, SHORT_NAME);
+             break;
+          case 'B':
+             if(repeat_count<=1)
+                result += to_str((Month)dt.mon, FULL_NAME);
+             break;
+          case 'c':
+             if(repeat_count<=1) {
+                result += to_str(day_of_week(dt.year, dt.mon, dt.day), SHORT_NAME)+" ";
+                result += to_str((Month)dt.mon, SHORT_NAME)+" ";
+                result += StringFormat("%2d ", dt.day);
+                result += StringFormat("%02d:%02d:%02d ", dt.hour, dt.min, dt.sec);
+                result += IntegerToString(dt.year);
+             }
+             break;
+          case 'C':
+             if(repeat_count<=1)
+                result += IntegerToString(dt.year/100);
+             break;
+          case 'd':
+             if(repeat_count<2)
+                result += pad_int(dt.day,2);
+             break;
+          case 'D':
+             if(repeat_count==1)
+                result += StringFormat("%02d/%02d/%02d", dt.mon, dt.day, (int)(dt.year%100));
+             else if(repeat_count==2)
+                result += pad_int(dt.day,2);
+             break;
+          case 'e':
+             if(repeat_count==1)
+                result += StringFormat("%2d", dt.day);
+             break;
+          case 'F':
+             if(repeat_count==1)
+                result += StringFormat("%lld-%02d-%02d", dt.year, dt.mon, dt.day);
+             break;
+          case 'j':
+             if(repeat_count==1)
+                result += pad_int(day_of_year(ts),3);
+             break;
+          case 'k':
+             if(repeat_count==1)
+                result += StringFormat("%2d", dt.hour);
+             break;
+          case 'l':
+             if(repeat_count==1)
+                result += StringFormat("%2d", hour24_to_12(dt.hour));
+             break;
+          case 'm':
+             if(repeat_count==1)
+                result += pad_int(dt.mon,2);
+             else if(repeat_count==2)
+                result += pad_int(dt.min,2);
+             break;
+          case 'M':
+             if(repeat_count==1)
+                result += pad_int(dt.min,2);
+             else if(repeat_count==2)
+                result += pad_int(dt.mon,2);
+             else if(repeat_count==3)
+                result += to_str((Month)dt.mon, UPPERCASE_NAME);
+             break;
+          case 'n':
+             result += "\n";
+             break;
+          case 'p':
+             result += dt.hour<12?"AM":"PM";
+             break;
+          case 'P':
+             result += dt.hour<12?"am":"pm";
+             break;
+          case 'r':
+             if(repeat_count==1)
+                result += StringFormat("%02d:%02d:%02d %s", hour24_to_12(dt.hour), dt.min, dt.sec, dt.hour<12?"AM":"PM");
+             break;
+          case 'R':
+             if(repeat_count==1)
+                result += StringFormat("%02d:%02d", dt.hour, dt.min);
+             break;
+          case 's':
+             if(repeat_count==1)
+                result += IntegerToString(ts);
+             else if(repeat_count==3)
+                result += IntegerToString(dt.ms);
+             break;
+          case 'S':
+             if(repeat_count<=2)
+                result += pad_int(dt.sec,2);
+             if(repeat_count==3)
+                result += IntegerToString(dt.ms);
+             break;
+          case 't':
+             if(repeat_count<=1)
+                result += "\t";
+             break;
+          case 'T':
+             if(repeat_count==1)
+                result += StringFormat("%02d:%02d:%02d", dt.hour, dt.min, dt.sec);
+             break;
+          case 'u':
+             if(repeat_count==1) {
+                int dw = day_of_week(dt.year, dt.mon, dt.day);
+                if(dw==0) dw=7;
+                result += IntegerToString(dw);
+             }
+             break;
+          case 'w':
+             if(repeat_count==1)
+                result += IntegerToString(day_of_week(dt.year, dt.mon, dt.day));
+             else if(repeat_count==3)
+                result += to_str(day_of_week(dt.year, dt.mon, dt.day), SHORT_NAME);
+             break;
+          case 'W':
+             if(repeat_count==3)
+                result += to_str(day_of_week(dt.year, dt.mon, dt.day), UPPERCASE_NAME);
+             break;
+          case 'y':
+             if(repeat_count==1)
+                result += IntegerToString(dt.year%100);
+             break;
+          case 'Y':
+             if(repeat_count==1)
+                result += IntegerToString(dt.year);
+             break;
+          case 'z':
+             if(repeat_count==1) {
+                TimeZoneStruct tz = to_time_zone_struct(utc_offset);
+                string sign = tz.is_positive?"+":"-";
+                result += sign+pad_int(tz.hour,2)+pad_int(tz.min,2);
+             }
+             break;
+          case 'Z':
+             result += "UTC";
+             break;
+       }
+    }
+
+   /// \brief Convert timestamp to string with custom format.
+   ///
+   /// This function works similarly to the C++ `strftime` implementation and
+   /// supports most of its specifiers along with several custom ones.
+   ///
+   /// \param format_str Format string with specifiers, e.g. "%H:%M:%S".
+   /// \param timestamp  Timestamp in seconds.
+   /// \param utc_offset UTC offset in seconds (default 0).
+   /// \return Formatted string according to \p format_str.
+   string to_string(const string &format_str, long timestamp, int utc_offset=0) {
+       string result="";
+       if(StringLen(format_str)==0) return result;
+       DateTimeStruct dt = to_date_time(timestamp);
+       bool is_command=false;
+       int repeat_count=0;
+       char last_char = StringGetChar(format_str,0);
+       if(last_char!='%') result+=CharToString(last_char);
+       for(int i=0;i<StringLen(format_str);++i) {
+          char current_char = StringGetChar(format_str,i);
+          if(!is_command) {
+             if(current_char=='%') {
+                ++repeat_count;
+                if(repeat_count==2) {
+                   result += "%";
+                   repeat_count=0;
+                }
+                continue;
+             }
+             if(!repeat_count) {
+                result += CharToString(current_char);
+                continue;
+             }
+             last_char=current_char;
+             is_command=true;
+             continue;
+          }
+          if(last_char==current_char) {
+             ++repeat_count;
+             continue;
+          }
+          process_format_impl(last_char, repeat_count, timestamp, utc_offset, dt, result);
+          repeat_count=0;
+          is_command=false;
+          --i;
+       }
+       if(is_command)
+          process_format_impl(last_char, repeat_count, timestamp, utc_offset, dt, result);
+       return result;
+    }
+
+    /// \brief Alias for \ref to_string.
+    /// \copydoc to_string
+    string to_str(const string &format_str, long timestamp, int utc_offset=0) {
+       return to_string(format_str, timestamp, utc_offset);
+    }
+
+    /// \brief Convert millisecond timestamp to string with custom format.
+    ///
+    /// Works the same as \ref to_string but accepts a timestamp in milliseconds.
+    ///
+    /// \param format_str Format string with specifiers.
+    /// \param timestamp_ms Timestamp in milliseconds.
+    /// \param utc_offset UTC offset in seconds (default 0).
+    /// \return Formatted string according to \p format_str.
+    string to_string_ms(const string &format_str, long timestamp_ms, int utc_offset=0) {
+       string result="";
+       if(StringLen(format_str)==0) return result;
+       DateTimeStruct dt = to_date_time_ms(timestamp_ms);
+       bool is_command=false;
+       int repeat_count=0;
+       char last_char = StringGetChar(format_str,0);
+       if(last_char!='%') result+=CharToString(last_char);
+       for(int i=0;i<StringLen(format_str);++i) {
+          char current_char = StringGetChar(format_str,i);
+          if(!is_command) {
+             if(current_char=='%') {
+                ++repeat_count;
+                if(repeat_count==2) {
+                   result += "%";
+                   repeat_count=0;
+                }
+                continue;
+             }
+             if(!repeat_count) {
+                result += CharToString(current_char);
+                continue;
+             }
+             last_char=current_char;
+             is_command=true;
+             continue;
+          }
+          if(last_char==current_char) {
+             ++repeat_count;
+             continue;
+          }
+          process_format_impl(last_char, repeat_count, ms_to_sec(timestamp_ms), utc_offset, dt, result);
+          repeat_count=0;
+          is_command=false;
+          --i;
+       }
+       if(is_command)
+          process_format_impl(last_char, repeat_count, ms_to_sec(timestamp_ms), utc_offset, dt, result);
+       return result;
+    }
+
+    /// \brief Alias for \ref to_string_ms.
+    /// \copydoc to_string_ms
+    string to_str_ms(const string &format_str, long timestamp_ms, int utc_offset=0) {
+       return to_string_ms(format_str, timestamp_ms, utc_offset);
+    }
+
+    //----------------------------------------------------------------------
+    // ISO8601 helpers
+    //----------------------------------------------------------------------
+
+    /// \brief Convert timestamp to ISO8601 string.
+    /// \param ts Timestamp in seconds.
+    /// \return ISO8601 formatted string (YYYY-MM-DDTHH:MM:SS).
+    string to_iso8601(long ts) {
+       DateTimeStruct dt = to_date_time(ts);
+       return StringFormat("%lld-%02d-%02dT%02d:%02d:%02d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+    }
+
+    /// \brief Convert millisecond timestamp to ISO8601 string.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return ISO8601 formatted string with milliseconds.
+    string to_iso8601_ms(long ts_ms) {
+       DateTimeStruct dt = to_date_time_ms(ts_ms);
+       return StringFormat("%lld-%02d-%02dT%02d:%02d:%02d.%03d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+    }
+
+    /// \brief Convert timestamp to ISO8601 date string.
+    /// \param ts Timestamp in seconds.
+    /// \return Date in ISO8601 format (YYYY-MM-DD).
+    string to_iso8601_date(long ts) {
+       DateTimeStruct dt = to_date_time(ts);
+       return StringFormat("%lld-%02d-%02d", dt.year, dt.mon, dt.day);
+    }
+
+    /// \brief Convert timestamp to ISO8601 time string.
+    /// \param ts Timestamp in seconds.
+    /// \return Time in ISO8601 format (HH:MM:SS).
+    string to_iso8601_time(long ts) {
+       DateTimeStruct dt = to_date_time(ts);
+       return StringFormat("%02d:%02d:%02d", dt.hour, dt.min, dt.sec);
+    }
+
+    /// \brief Convert millisecond timestamp to ISO8601 time string.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return Time in ISO8601 format with milliseconds.
+    string to_iso8601_time_ms(long ts_ms) {
+       DateTimeStruct dt = to_date_time_ms(ts_ms);
+       return StringFormat("%02d:%02d:%02d.%03d", dt.hour, dt.min, dt.sec, dt.ms);
+    }
+
+    /// \brief Convert timestamp to ISO8601 string in UTC.
+    /// \param ts Timestamp in seconds.
+    /// \return ISO8601 string with trailing 'Z'.
+    string to_iso8601_utc(long ts) {
+       return to_iso8601(ts)+"Z";
+    }
+
+    /// \brief Convert millisecond timestamp to ISO8601 string in UTC.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return ISO8601 string with milliseconds and trailing 'Z'.
+    string to_iso8601_utc_ms(long ts_ms) {
+       return to_iso8601_ms(ts_ms)+"Z";
+    }
+
+    /// \brief Convert timestamp to ISO8601 string with timezone offset.
+    /// \param ts Timestamp in seconds.
+    /// \param utc_offset Offset from UTC in seconds.
+    /// \return ISO8601 string with timezone offset.
+    string to_iso8601(long ts, int utc_offset) {
+       TimeZoneStruct tz = to_time_zone(utc_offset);
+       string sign = tz.is_positive?"+":"-";
+       return StringFormat("%s%s%.2d:%.2d", to_iso8601(ts), sign, tz.hour, tz.min);
+    }
+
+    /// \brief Convert millisecond timestamp to ISO8601 string with timezone offset.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \param utc_offset Offset from UTC in seconds.
+    /// \return ISO8601 string with milliseconds and timezone offset.
+    string to_iso8601_ms(long ts_ms, int utc_offset) {
+       TimeZoneStruct tz = to_time_zone(utc_offset);
+       string sign = tz.is_positive?"+":"-";
+       return StringFormat("%s%s%.2d:%.2d", to_iso8601_ms(ts_ms), sign, tz.hour, tz.min);
+    }
+
+    //----------------------------------------------------------------------
+    // MQL5 specific helpers
+    //----------------------------------------------------------------------
+
+    /// \brief Convert timestamp to MQL5 date-time string.
+    /// \param ts Timestamp in seconds.
+    /// \return String in format "YYYY.MM.DD HH:MM:SS".
+    string to_mql5_date_time(long ts) {
+       DateTimeStruct dt = to_date_time(ts);
+       return StringFormat("%lld.%02d.%02d %02d:%02d:%02d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+    }
+
+    /// \brief Convert timestamp to MQL5 date string.
+    /// \param ts Timestamp in seconds.
+    /// \return String in format "YYYY.MM.DD".
+    string to_mql5_date(long ts) {
+       DateTimeStruct dt = to_date_time(ts);
+       return StringFormat("%lld.%02d.%02d", dt.year, dt.mon, dt.day);
+    }
+
+    /// \brief Convert timestamp to MQL5 time string.
+    /// \param ts Timestamp in seconds.
+    /// \return String in format "HH:MM:SS".
+    string to_mql5_time(long ts) {
+       DateTimeStruct dt = to_date_time(ts);
+       return StringFormat("%02d:%02d:%02d", dt.hour, dt.min, dt.sec);
+    }
+
+    /// \brief Alias for \ref to_mql5_date_time.
+    /// \copydoc to_mql5_date_time
+    string to_mql5_full(long ts) { return to_mql5_date_time(ts); }
+
+    /// \brief Convert timestamp to Windows-compatible filename.
+    /// \param ts Timestamp in seconds.
+    /// \return String in format "YYYY-MM-DD_HH-MM-SS".
+    string to_windows_filename(long ts) {
+       DateTimeStruct dt = to_date_time(ts);
+       return StringFormat("%lld-%02d-%02d_%02d-%02d-%02d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+    }
+
+    /// \brief Convert millisecond timestamp to Windows-compatible filename.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return String in format "YYYY-MM-DD_HH-MM-SS-SSS".
+    string to_windows_filename_ms(long ts_ms) {
+       DateTimeStruct dt = to_date_time_ms(ts_ms);
+       return StringFormat("%lld-%02d-%02d_%02d-%02d-%02d-%03d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+    }
+
+    /// \brief Convert timestamp to human-readable string.
+    /// \param ts Timestamp in seconds.
+    /// \return String in format "YYYY-MM-DD HH:MM:SS".
+    string to_human_readable(long ts) {
+       DateTimeStruct dt = to_date_time(ts);
+       return StringFormat("%lld-%02d-%02d %02d:%02d:%02d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+    }
+
+    /// \brief Convert millisecond timestamp to human-readable string.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return String in format "YYYY-MM-DD HH:MM:SS.SSS".
+    string to_human_readable_ms(long ts_ms) {
+       DateTimeStruct dt = to_date_time_ms(ts_ms);
+       return StringFormat("%lld-%02d-%02d %02d:%02d:%02d.%03d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+    }
+
+    /// \}
+
+}; // namespace time_shield
+
+#endif // __TIME_SHIELD_TIME_FORMATTING_MQH__

--- a/MQL5/Include/time_shield/time_parser.mqh
+++ b/MQL5/Include/time_shield/time_parser.mqh
@@ -1,0 +1,258 @@
+//+------------------------------------------------------------------+
+//|                                            time_parser.mqh       |
+//|                        Time Shield - MQL5 Time Parser            |
+//|                                      Copyright 2025, NewYaroslav |
+//|                   https://github.com/NewYaroslav/time-shield-cpp |
+//+------------------------------------------------------------------+
+#ifndef __TIME_SHIELD_TIME_PARSER_MQH__
+#define __TIME_SHIELD_TIME_PARSER_MQH__
+
+/// \file time_parser.mqh
+/// \ingroup mql5
+/// \brief Header with functions for parsing ISO8601 strings
+/// and converting them to timestamps.
+///
+/// This file contains utilities to parse ISO8601 date and time strings,
+/// extract month numbers and convert parsed values into different
+/// timestamp representations.
+
+#property copyright "Copyright 2025, NewYaroslav"
+#property link      "https://github.com/NewYaroslav/time-shield-cpp"
+#property strict
+
+#include <time_shield/enums.mqh>
+#include <time_shield/constants.mqh>
+#include <time_shield/date_time_struct.mqh>
+#include <time_shield/time_zone_struct.mqh>
+#include <time_shield/validation.mqh>
+#include <time_shield/time_conversions.mqh>
+
+namespace time_shield {
+
+    /// \defgroup time_parsing Time Parsing
+    /// \brief A comprehensive set of functions for parsing and converting date and time strings.
+    /// \{
+
+    /// \brief Get the month number by name.
+    /// \param month The name of the month as a string.
+    /// \return The month number corresponding to the given name, or 0 on error.
+    int get_month_number(const string &month)
+    {
+       if(StringLen(month)==0)
+          return 0;
+       string month_copy = month;
+       string tmp = "";
+       StringConcatenate(tmp,
+                        StringUpper(StringSubstr(month_copy,0,1)),
+                        StringLower(StringSubstr(month_copy,1)));
+       month_copy = tmp;
+       static const string short_names[] = {"Jan","Feb","Mar","Apr","May","Jun",
+                                            "Jul","Aug","Sep","Oct","Nov","Dec"};
+       static const string full_names[]  = {"January","February","March","April","May","June",
+                                            "July","August","September","October","November","December"};
+       for(int i=0;i<MONTHS_PER_YEAR;++i)
+       {
+          if(month_copy==short_names[i] || month_copy==full_names[i])
+             return i+1;
+       }
+       return 0;
+    }
+
+    /// \brief Alias for get_month_number function.
+    /// \copydoc get_month_number
+    int month_of_year(const string &month) { return get_month_number(month); }
+
+//------------------------------------------------------------------------------
+
+    /// \brief Get the month number by name, with output parameter.
+    /// \param month The name of the month as a string.
+    /// \param value Reference to store the month number if found.
+    /// \return True if the month name is valid, false otherwise.
+    bool try_get_month_number(const string &month, int &value)
+    {
+       int res = get_month_number(month);
+       if(res==0)
+          return false;
+       value = res;
+       return true;
+    }
+
+    /// \brief Alias for try_get_month_number function.
+    /// \copydoc try_get_month_number
+    bool get_month_number(const string &month, int &value) { return try_get_month_number(month,value); }
+
+    /// \brief Alias for try_get_month_number function.
+    /// \copydoc try_get_month_number
+    bool month_of_year(const string &month, int &value) { return try_get_month_number(month,value); }
+
+//------------------------------------------------------------------------------
+
+    /// \brief Parse a time zone string into a TimeZoneStruct.
+    /// \details Parses a time zone string in the format "+hh:mm", "-hh:mm" or "Z".
+    /// If the string is empty or "Z", UTC is assumed.
+    /// \param tz_str The time zone string.
+    /// \param tz The TimeZoneStruct to be filled.
+    /// \return True if the parsing is successful and the time zone is valid, false otherwise.
+    bool parse_time_zone(const string &tz_str, TimeZoneStruct &tz)
+    {
+       if(StringLen(tz_str)==0 || tz_str=="Z")
+       {
+          tz.hour=0; tz.min=0; tz.is_positive=true; return true;
+       }
+       tz.is_positive = (StringGetChar(tz_str,0)=='+');
+       tz.hour = (int)StringToInteger(StringSubstr(tz_str,1,2));
+       tz.min  = (int)StringToInteger(StringSubstr(tz_str,4,2));
+       return is_valid_time_zone(tz);
+    }
+
+    /// \brief Alias for parse_time_zone function.
+    /// \copydoc parse_time_zone
+    bool parse_tz(const string &tz_str, TimeZoneStruct &tz) { return parse_time_zone(tz_str, tz); }
+
+//------------------------------------------------------------------------------
+
+    /// \brief Parse a date and time string in ISO8601 format.
+    /// \param input The input string in ISO8601 format.
+    /// \param dt The DateTimeStruct to be filled with parsed values.
+    /// \param tz The TimeZoneStruct to be filled with parsed time zone.
+    /// \return True if parsing succeeds and the date and time values are valid, false otherwise.
+    bool parse_iso8601(const string &input, DateTimeStruct &dt, TimeZoneStruct &tz)
+    {
+       dt = create_date_time_struct(0);
+       tz = create_time_zone_struct(0,0);
+
+       string date_part=input;
+       string time_part="";
+       int posT=StringFind(input,"T");
+       if(posT<0) posT=StringFind(input," ");
+       if(posT>=0)
+       {
+          date_part=StringSubstr(input,0,posT);
+          time_part=StringSubstr(input,posT+1);
+       }
+
+       string parts[];
+       int cnt=StringSplit(date_part,'-',parts);
+       if(cnt<3)
+       {
+          cnt=StringSplit(date_part,'/',parts);
+          if(cnt<3)
+             cnt=StringSplit(date_part,'.',parts);
+       }
+       if(cnt<3)
+          return false;
+       dt.year=(long)StringToInteger(parts[0]);
+       dt.mon =(int)StringToInteger(parts[1]);
+       dt.day =(int)StringToInteger(parts[2]);
+
+       if(StringLen(time_part)>0)
+       {
+          string tz_str="";
+          int zpos=StringFind(time_part,"Z");
+          int ppos=StringFind(time_part,"+");
+          int npos=StringFind(time_part,"-");
+          int tzpos=-1;
+          if(zpos>=0){ tzpos=zpos; tz_str=StringSubstr(time_part,zpos); }
+          else if(ppos>=0){ tzpos=ppos; tz_str=StringSubstr(time_part,ppos); }
+          else if(npos>0){ tzpos=npos; tz_str=StringSubstr(time_part,npos); }
+          if(tzpos>=0)
+             time_part=StringSubstr(time_part,0,tzpos);
+
+          string tparts[];
+          int tcnt=StringSplit(time_part,':',tparts);
+          if(tcnt<2)
+             return is_valid_date_time(dt);
+          dt.hour=(int)StringToInteger(tparts[0]);
+          dt.min =(int)StringToInteger(tparts[1]);
+          if(tcnt>=3)
+          {
+             string sec_part=tparts[2];
+             int dot=StringFind(sec_part,'.');
+             if(dot>=0)
+             {
+                dt.sec=(int)StringToInteger(StringSubstr(sec_part,0,dot));
+                dt.ms =(int)StringToInteger(StringSubstr(sec_part,dot+1));
+             }
+             else
+                dt.sec=(int)StringToInteger(sec_part);
+          }
+          if(StringLen(tz_str)>0)
+             if(!parse_time_zone(tz_str,tz)) return false;
+       }
+       return is_valid_date_time(dt);
+    }
+
+    /// \brief Convert an ISO8601 string to a timestamp (ts_t).
+    /// \param str The ISO8601 string.
+    /// \param ts The timestamp to be filled.
+    /// \return True if the parsing and conversion are successful, false otherwise.
+    bool str_to_ts(const string &str, long &ts)
+    {
+       DateTimeStruct dt; TimeZoneStruct tz;
+       if(!parse_iso8601(str, dt, tz)) return false;
+       ts = to_timestamp(dt) + to_offset(tz);
+       return true;
+    }
+
+    /// \brief Convert an ISO8601 string to a millisecond timestamp (ts_ms_t).
+    /// \param str The ISO8601 string.
+    /// \param ts The millisecond timestamp to be filled.
+    /// \return True if the parsing and conversion are successful, false otherwise.
+    bool str_to_ts_ms(const string &str, long &ts)
+    {
+       DateTimeStruct dt; TimeZoneStruct tz;
+       if(!parse_iso8601(str, dt, tz)) return false;
+       ts = to_timestamp_ms(dt) + sec_to_ms(to_offset(tz));
+       return true;
+    }
+
+    /// \brief Convert an ISO8601 string to a floating-point timestamp (fts_t).
+    /// \param str The ISO8601 string.
+    /// \param ts The floating-point timestamp to be filled.
+    /// \return True if the parsing and conversion are successful, false otherwise.
+    bool str_to_fts(const string &str, double &ts)
+    {
+       DateTimeStruct dt; TimeZoneStruct tz;
+       if(!parse_iso8601(str, dt, tz)) return false;
+       ts = to_ftimestamp(dt) + (double)to_offset(tz);
+       return true;
+    }
+
+    /// \brief Convert an ISO8601 string to a timestamp (ts_t).
+    /// \details Returns 0 if parsing fails.
+    /// \param str The ISO8601 string.
+    /// \return Timestamp value or 0 on error.
+    long ts(const string &str)
+    {
+       long v=0;
+       str_to_ts(str,v);
+       return v;
+    }
+
+    /// \brief Convert an ISO8601 string to a millisecond timestamp (ts_ms_t).
+    /// \details Returns 0 if parsing fails.
+    /// \param str The ISO8601 string.
+    /// \return Millisecond timestamp value or 0 on error.
+    long ts_ms(const string &str)
+    {
+       long v=0;
+       str_to_ts_ms(str,v);
+       return v;
+    }
+
+    /// \brief Convert an ISO8601 string to a floating-point timestamp (fts_t).
+    /// \details Returns 0.0 if parsing fails.
+    /// \param str The ISO8601 string.
+    /// \return Floating-point timestamp or 0.0 on error.
+    double fts(const string &str)
+    {
+       double v=0.0;
+       str_to_fts(str,v);
+       return v;
+    }
+
+    /// \}
+
+}; // namespace time_shield
+
+#endif // __TIME_SHIELD_TIME_PARSER_MQH__


### PR DESCRIPTION
## Summary
- add new `time_parser.mqh` with ISO8601 parsing helpers
- add extended time conversions utilities
- document ISO8601 formatting helpers
- fix StringConcatenate usage in month parser

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6856b241c538832cb0ac09cd9e1d8159