### PR TITLE
Add library initialization helper

### DIFF
--- a/MQL5/Include/time_shield.mqh
+++ b/MQL5/Include/time_shield.mqh
@@ -55,4 +55,7 @@
 // Functions for parsing time in various standard formats
 #include <time_shield/time_parser.mqh>
 
+// Functions for initializing the library
+#include <time_shield/initialization.mqh>
+
 #endif // __TIME_SHIELD_MQH__

--- a/MQL5/Include/time_shield/initialization.mqh
+++ b/MQL5/Include/time_shield/initialization.mqh
@@ -1,0 +1,41 @@
+//+------------------------------------------------------------------+
+//|                                                   initialization.mqh |
+//|                  Time Shield - Library Initialization Functions  |
+//|                                Copyright 2025, NewYaroslav        |
+//|                 https://github.com/NewYaroslav/time-shield-cpp    |
+//+------------------------------------------------------------------+
+#ifndef __TIME_SHIELD_INITIALIZATION_MQH__
+#define __TIME_SHIELD_INITIALIZATION_MQH__
+
+/// \file initialization.mqh
+/// \ingroup mql5
+/// \brief Functions for initializing the Time Shield library.
+///
+/// Call ::initialize_library() once at the beginning of OnStart before
+/// using other functions from the library. It currently triggers the
+/// lazy initialization used by microseconds().
+
+#property copyright "Copyright 2025, NewYaroslav"
+#property link      "https://github.com/NewYaroslav/time-shield-cpp"
+#property strict
+
+#include <time_shield/time_utils.mqh>
+
+namespace time_shield {
+
+   /// \defgroup time_initialization Library Initialization
+   /// \brief Functions used to initialize the Time Shield library.
+   /// \{
+
+   /// \brief Initialize the Time Shield library.
+   ///
+   /// This function performs all necessary setup steps. Call it in
+   /// `OnStart` before invoking any other Time Shield functions.
+   void initialize_library() {
+      microseconds();
+   }
+
+   /// \}
+}; // namespace time_shield
+
+#endif // __TIME_SHIELD_INITIALIZATION_MQH__

--- a/MQL5/Scripts/time_shield/examples/time_conversions_demo.mq5
+++ b/MQL5/Scripts/time_shield/examples/time_conversions_demo.mq5
@@ -1,0 +1,49 @@
+//+------------------------------------------------------------------+
+//|                                    time_conversions_demo.mq5 |
+//|                     Time Shield - Conversions Examples       |
+//|                      Copyright 2025, NewYaroslav              |
+//|              https://github.com/NewYaroslav/time-shield-cpp   |
+//+------------------------------------------------------------------+
+#property script_show_inputs
+#property strict
+
+#include <TimeShield.mqh>
+
+using namespace time_shield;
+
+void OnStart()
+{
+    initialize_library();
+
+    double sec = 123.456;
+    Print("ns_of_sec: ", ns_of_sec(sec));
+    Print("us_of_sec: ", us_of_sec(sec));
+    Print("ms_of_sec: ", ms_of_sec(sec));
+
+    long ms = sec_to_ms(sec);
+    Print("sec_to_ms: ", ms);
+    Print("ms_to_sec: ", ms_to_sec(ms));
+    Print("ms_to_fsec: ", DoubleToString(ms_to_fsec(ms), 3));
+
+    Print("min_to_sec(2.5): ", min_to_sec(2.5));
+    Print("sec_to_min(150): ", sec_to_min(150));
+
+    Print("hour_to_ms(1.5): ", hour_to_ms(1.5));
+    Print("hour24_to_12(15): ", hour24_to_12(15));
+
+    datetime ts = to_ts(2024, JUN, 21, 14, 30, 0);
+    long ts_ms = to_ts_ms(2024, JUN, 21, 14, 30, 0, 250);
+
+    DateTimeStruct dt = to_dt_ms(ts_ms);
+    Print("to_dt_ms: ", dt.year, "-", dt.mon, "-", dt.day, " ", dt.hour, ":", dt.min, ":", dt.sec, ".", dt.ms);
+
+    Print("start_of_day: ", start_of_day(ts));
+    Print("end_of_day_ms: ", end_of_day_ms(ts_ms));
+    Print("next_day_ms: ", next_day_ms(ts_ms));
+
+    Print("day_of_year: ", day_of_year(ts));
+    Print("month_of_year: ", month_of_year(ts));
+    Print("day_of_month: ", day_of_month(ts));
+    Print("start_of_year_date(2024): ", start_of_year_date(2024));
+    Print("day_of_week_date(2024, JUN, 21): ", day_of_week_date(2024, JUN, 21));
+}

--- a/MQL5/Scripts/time_shield/examples/time_formatting_demo.mq5
+++ b/MQL5/Scripts/time_shield/examples/time_formatting_demo.mq5
@@ -1,0 +1,28 @@
+//+------------------------------------------------------------------+
+//|                                     time_formatting_demo.mq5 |
+//|                   Time Shield - Formatting Examples           |
+//|                      Copyright 2025, NewYaroslav                |
+//|              https://github.com/NewYaroslav/time-shield-cpp     |
+//+------------------------------------------------------------------+
+#property script_show_inputs
+#property strict
+
+#include <TimeShield.mqh>
+
+using namespace time_shield;
+
+void OnStart()
+{
+    initialize_library();
+
+    datetime ts = to_ts(2024, JUN, 21, 15, 30, 5);
+    long ts_ms = to_ts_ms(2024, JUN, 21, 15, 30, 5, 123);
+
+    Print("Custom: ", to_string("%Y-%m-%d %H:%M:%S", ts));
+    Print("ISO8601: ", to_iso8601(ts));
+    Print("ISO8601 UTC ms: ", to_iso8601_utc_ms(ts_ms));
+    Print("ISO8601 +02: ", to_iso8601(ts, 2*3600));
+    Print("MQL5: ", to_mql5_date_time(ts));
+    Print("Windows filename: ", to_windows_filename(ts));
+    Print("Human readable: ", to_human_readable_ms(ts_ms));
+}

--- a/MQL5/Scripts/time_shield/examples/time_parser_demo.mq5
+++ b/MQL5/Scripts/time_shield/examples/time_parser_demo.mq5
@@ -1,0 +1,48 @@
+//+------------------------------------------------------------------+
+//|                                     time_parser_demo.mq5 |
+//|                   Time Shield - Parsing Examples         |
+//|                      Copyright 2025, NewYaroslav          |
+//|              https://github.com/NewYaroslav/time-shield-cpp |
+//+------------------------------------------------------------------+
+#property script_show_inputs
+#property strict
+
+#include <TimeShield.mqh>
+
+using namespace time_shield;
+
+void OnStart()
+{
+    initialize_library();
+
+    string iso = "2024-11-25T14:30:00+01:00";
+
+    datetime ts;
+    if(str_to_ts(iso, ts))
+        Print("ts: ", ts, " -> ", to_iso8601(ts));
+    else
+        Print("Failed to parse: ", iso);
+
+    long ts_ms;
+    if(str_to_ts_ms(iso, ts_ms))
+        Print("ts_ms: ", ts_ms);
+
+    double fts_val;
+    if(str_to_fts(iso, fts_val))
+        Print("fts: ", DoubleToString(fts_val, 2));
+
+    DateTimeStruct dt;
+    TimeZoneStruct tz;
+    if(parse_iso8601(iso, dt, tz))
+    {
+        string sign = tz.is_positive ? "+" : "-";
+        Print("dt: ", dt.year, "-", dt.mon, "-", dt.day, " ", dt.hour, ":", dt.min, ":", dt.sec, ".", dt.ms,
+              " TZ ", sign, tz.hour, ":", tz.min);
+    }
+
+    int mon = get_month_number("March");
+    Print("Month number for March: ", mon);
+
+    datetime direct = ts("2024-01-01T00:00:00Z");
+    Print("ts() shortcut: ", direct);
+}

--- a/MQL5/Scripts/time_shield/tests/test_eet_to_gmt.mq5
+++ b/MQL5/Scripts/time_shield/tests/test_eet_to_gmt.mq5
@@ -1,0 +1,38 @@
+//+------------------------------------------------------------------+
+//|                                            test_eet_to_gmt.mq5 |
+//|                      Time Shield - Function Test                |
+//|                      Copyright 2025, NewYaroslav                |
+//|              https://github.com/NewYaroslav/time-shield-cpp     |
+//+------------------------------------------------------------------+
+#property script_show_inputs
+#property strict
+
+#include <TimeShield.mqh>
+
+using namespace time_shield;
+
+void OnStart()
+{
+    initialize_library();
+
+    // Winter timestamp: 2024-01-15 12:00:00 EET
+    datetime winter_eet = to_ts(2024, JAN, 15, 12, 0, 0);
+    datetime winter_expected = to_ts(2024, JAN, 15, 10, 0, 0);
+    datetime winter_gmt = eet_to_gmt(winter_eet);
+
+    if(winter_gmt == winter_expected)
+        Print("Winter conversion passed");
+    else
+        Print("Winter conversion failed: ", winter_gmt, " != ", winter_expected);
+
+    // Summer timestamp: 2024-07-15 12:00:00 EET (EEST)
+    datetime summer_eet = to_ts(2024, JUL, 15, 12, 0, 0);
+    datetime summer_expected = to_ts(2024, JUL, 15, 9, 0, 0);
+    datetime summer_gmt = eet_to_gmt(summer_eet);
+
+    if(summer_gmt == summer_expected)
+        Print("Summer conversion passed");
+    else
+        Print("Summer conversion failed: ", summer_gmt, " != ", summer_expected);
+}
+

--- a/include/time_shield_cpp/time_shield.hpp
+++ b/include/time_shield_cpp/time_shield.hpp
@@ -23,6 +23,7 @@
 #include "time_shield/time_zone_conversions.hpp" ///< Functions for converting between time zones.
 #include "time_shield/time_formatting.hpp"       ///< Functions for formatting time in various standard formats.
 #include "time_shield/time_parser.hpp"           ///< Functions for parsing time in various standard formats.
+#include "time_shield/initialization.hpp"        ///< Library initialization helpers.
 
 /// \namespace tsh
 /// \brief Alias for the namespace time_shield.

--- a/include/time_shield_cpp/time_shield/initialization.hpp
+++ b/include/time_shield_cpp/time_shield/initialization.hpp
@@ -1,0 +1,30 @@
+#pragma once
+#ifndef _TIME_SHIELD_INITIALIZATION_HPP_INCLUDED
+#define _TIME_SHIELD_INITIALIZATION_HPP_INCLUDED
+
+/// \file initialization.hpp
+/// \brief Library initialization helpers.
+///
+/// Call ::initialize_library() once before using other functions.
+
+#include "time_utils.hpp"
+
+namespace time_shield {
+
+/// \defgroup time_initialization Library Initialization
+/// \brief Functions used to initialize the Time Shield library.
+/// \{
+
+/// \brief Initialize the Time Shield library.
+///
+/// This function performs any required setup steps. Currently it
+/// triggers the lazy initialization inside microseconds().
+inline void initialize_library() {
+    microseconds();
+}
+
+/// \}
+
+}; // namespace time_shield
+
+#endif // _TIME_SHIELD_INITIALIZATION_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- provide `initialize_library` for preloading lazy helpers
- include new header in the main library
- call initializer in all example and test scripts

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_6856d83a5294832c93a6d861d18a3516