### PR TITLE
Add NtpClient usage example

### DIFF
--- a/examples/ntp_client_example.cpp
+++ b/examples/ntp_client_example.cpp
@@ -1,0 +1,54 @@
+/// \file ntp_client_example.cpp
+/// \brief Demonstrates usage of time_shield::NtpClient.
+///
+/// This example queries an NTP server, measures the time offset
+/// between the local machine and the server, then prints the
+/// current time without correction and with the measured offset applied.
+
+#include <iostream>
+#include <iomanip>
+#include <chrono>
+#include <ctime>
+#if defined(_WIN32)
+#   include <time_shield/ntp_client.hpp>
+
+int main() {
+    using namespace time_shield;
+
+    NtpClient client; // uses pool.ntp.org by default
+
+    std::cout << "Querying NTP server..." << std::endl;
+    if (!client.query()) {
+        std::cerr << "Failed to query NTP server. Error code: "
+                  << client.get_last_error_code() << std::endl;
+        return 1;
+    }
+
+    const int64_t offset_us = client.get_offset_us();
+
+    // Current local system time
+    auto now = std::chrono::system_clock::now();
+    auto now_time_t = std::chrono::system_clock::to_time_t(now);
+    std::cout << "Local time:    "
+              << std::put_time(std::gmtime(&now_time_t), "%Y-%m-%d %H:%M:%S")
+              << std::endl;
+
+    // Corrected time using the offset from the NTP server
+    auto corrected = std::chrono::system_clock::time_point(
+        std::chrono::microseconds(client.get_utc_time_us()));
+    auto corrected_time_t = std::chrono::system_clock::to_time_t(corrected);
+    std::cout << "Corrected time: "
+              << std::put_time(std::gmtime(&corrected_time_t), "%Y-%m-%d %H:%M:%S")
+              << std::endl;
+
+    std::cout << "Offset (us): " << offset_us << std::endl;
+    return 0;
+}
+
+#else
+int main() {
+    std::cout << "NtpClient is supported only on Windows." << std::endl;
+    return 0;
+}
+#endif
+


### PR DESCRIPTION
## Summary
- add example showing how to measure time offset with `NtpClient`

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68583c66eefc832cb6afb0f0e6638eee