### PR TITLE
Add Doxygen group for NTP functionality

### DIFF
--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -114,6 +114,30 @@ custom formats, ISO8601, and other standardized formats.
 */
 
 /*!
+\defgroup ntp NTP Client
+\brief Facilities for retrieving time using the Network Time Protocol.
+
+This module contains a minimal client capable of querying remote NTP
+servers to measure the offset between local and network time. It uses
+WinSock via the `WsaGuard` helper and therefore works only on Windows.
+
+### Features:
+- Query NTP servers and obtain the time offset.
+- Retrieve corrected UTC time in microseconds and milliseconds.
+- Automatic WinSock initialization through `WsaGuard`.
+- Requires network connectivity.
+
+### Example Usage:
+```cpp
+time_shield::NtpClient client;
+if (client.query()) {
+    int64_t offset = client.get_offset_us();
+    int64_t utc_ms = client.get_utc_time_ms();
+}
+```
+*/
+
+/*!
 \defgroup time_structures_time_conversions Time structure conversions
 \ingroup time_structures
 \ingroup time_conversions

--- a/include/time_shield_cpp/time_shield/ntp_client.hpp
+++ b/include/time_shield_cpp/time_shield/ntp_client.hpp
@@ -9,6 +9,7 @@
 /// and calculate the offset between local system time and the NTP-reported time.
 ///
 /// Currently only Windows is supported (WinSock-based implementation).
+/// \ingroup ntp
 
 #if defined(_WIN32)
 
@@ -28,6 +29,7 @@
 
 namespace time_shield {
 
+    /// \ingroup ntp
     /// \brief Simple Windows-only NTP client for measuring time offset.
     class NtpClient {
     public:

--- a/include/time_shield_cpp/time_shield/ntp_client/wsa_guard.hpp
+++ b/include/time_shield_cpp/time_shield/ntp_client/wsa_guard.hpp
@@ -1,6 +1,11 @@
+
 #pragma once
 #ifndef _TIME_SHIELD_WSA_GUARD_HPP_INCLUDED
 #define _TIME_SHIELD_WSA_GUARD_HPP_INCLUDED
+
+/// \file wsa_guard.hpp
+/// \brief Singleton guard for WinSock initialization.
+/// \ingroup ntp
 
 #include <winsock2.h>  // Must be included before windows.h
 #include <windows.h>   // (optional, but safe if later needed)
@@ -9,6 +14,7 @@
 
 namespace time_shield {
 
+    /// \ingroup ntp
     /// \brief Singleton guard for WinSock initialization.
     class WsaGuard {
     public:


### PR DESCRIPTION
## Summary
- document an `ntp` group in Doxygen with features and example
- link `NtpClient` and `WsaGuard` classes to the new group

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_685914550854832cb0dcb7d28a42d58d