### PR TITLE
Add time zone conversions docs

### DIFF
--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -114,6 +114,22 @@ custom formats, ISO8601, and other standardized formats.
 */
 
 /*!
+\defgroup time_zone_conversions Time Zone Conversions
+\ingroup time_conversions
+\brief Helpers for converting regional time zones to GMT.
+
+These functions convert Central and Eastern European Time to Greenwich
+Mean Time. Daylight saving time rules before and after 2002 are taken
+into account, so conversions are accurate for legacy timestamps as well.
+
+### Example Usage:
+```cpp
+ts_t cet_ts = time_shield::to_ts(2024, Month::JUN, 21, 12, 0, 0);
+ts_t gmt_ts = time_shield::cet_to_gmt(cet_ts);
+```
+*/
+
+/*!
 \defgroup ntp NTP Client
 \brief Facilities for retrieving time using the Network Time Protocol.
 
@@ -135,6 +151,12 @@ if (client.query()) {
     int64_t utc_ms = client.get_utc_time_ms();
 }
 ```
+*/
+
+/*!
+\defgroup time_conversions_time_zone_conversions Time zone conversion helpers
+\ingroup time_conversions
+\ingroup time_zone_conversions
 */
 
 /*!

--- a/include/time_shield_cpp/time_shield/time_zone_conversions.hpp
+++ b/include/time_shield_cpp/time_shield/time_zone_conversions.hpp
@@ -10,7 +10,10 @@
 
 namespace time_shield {
 
-    /// \ingroup time_conversions
+    /// \ingroup time_zone_conversions
+    /// \{
+
+    /// \ingroup time_conversions_time_zone_conversions
     /// \brief Convert Central European Time to Greenwich Mean Time.
     /// \param cet Timestamp in seconds in CET.
     /// \return Timestamp in seconds in GMT.
@@ -83,13 +86,15 @@ namespace time_shield {
         return cet - SEC_PER_HOUR;
     }
 
-    /// \ingroup time_conversions
+    /// \ingroup time_conversions_time_zone_conversions
     /// \brief Convert Eastern European Time to Greenwich Mean Time.
     /// \param eet Timestamp in seconds in EET.
     /// \return Timestamp in seconds in GMT.
     inline const ts_t eet_to_gmt(ts_t eet) {
         return cet_to_gmt(eet - SEC_PER_HOUR);
     }
+
+    /// \}
 
 } // namespace time_shield
 


### PR DESCRIPTION
## Summary
- add the `time_zone_conversions` group description
- link conversion helpers with the new group
- document combined `time_conversions_time_zone_conversions` group
- refine zone conversion groups in header

## Testing
- `cmake -S . -B build`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_685915a52fb4832ca37a23163f19476c