### PR TITLE
Add installable CMake package and cross-platform CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        std: [11, 17]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build
+
+  windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        std: [11, 17]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build
+        run: cmake --build build --config Release
+      - name: Test
+        run: ctest --test-dir build -C Release
+
+  macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        std: [11, 17]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build
+        run: cmake --build build
+      - name: Test
+        run: ctest --test-dir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,61 @@
-# При генерации Code::Blocks проекта с MinGW можно использовать так:
-# cmake -G "CodeBlocks - MinGW Makefiles" -S . -B build-cb
 cmake_minimum_required(VERSION 3.18)
-project(time_shield LANGUAGES CXX)
+project(time_shield_cpp VERSION 0.1.0 LANGUAGES CXX)
+
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(time_shield_cpp INTERFACE)
+add_library(time_shield_cpp::time_shield_cpp ALIAS time_shield_cpp)
+
+target_compile_features(time_shield_cpp INTERFACE cxx_std_11)
+
+target_include_directories(
+    time_shield_cpp
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/time_shield_cpp>
+        $<INSTALL_INTERFACE:include/time_shield_cpp>
+)
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+install(TARGETS time_shield_cpp EXPORT time_shield_cppTargets)
+install(DIRECTORY include/time_shield_cpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(
+    EXPORT time_shield_cppTargets
+    FILE time_shield_cppTargets.cmake
+    NAMESPACE time_shield_cpp::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/time_shield_cpp
+)
+
+configure_package_config_file(
+    cmake/time_shield_cppConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/time_shield_cppConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/time_shield_cpp
+)
+
+write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/time_shield_cppConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/time_shield_cppConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/time_shield_cppConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/time_shield_cpp
+)
+
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    set(is_top_level ON)
+else()
+    set(is_top_level OFF)
+endif()
+
+option(TIME_SHIELD_CPP_BUILD_EXAMPLES "Build examples" ${is_top_level})
+option(TIME_SHIELD_CPP_BUILD_TESTS "Build tests" ${is_top_level})
 
 if(MINGW OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(COMMON_WARN_FLAGS -Wall -Wextra -Wpedantic -Wconversion -Wsign-conversion -Wshadow)
@@ -11,58 +65,36 @@ if(MSVC)
     set(COMMON_WARN_FLAGS /W4 /wd4996)
 endif()
 
-if(NOT DEFINED CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# Пути к инклудам и библиотекам
-set(PROJECT_INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/time_shield_cpp
-)
-
-# Заголовочные файлы из include/
-file(GLOB_RECURSE PROJECT_HEADERS
-    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
-    include/*.hpp
-)
-
-# Создаём виртуальную цель для заголовков, чтобы отображались в IDE
+file(GLOB_RECURSE PROJECT_HEADERS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} include/*.hpp)
 add_custom_target(project_headers SOURCES ${PROJECT_HEADERS})
 
-# Находим все .cpp файлы в examples/
-file(GLOB EXAMPLES_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} examples/*.cpp)
-
-# Для каждого создаём отдельную цель
-foreach(example_src ${EXAMPLES_SOURCES})
-    get_filename_component(example_name ${example_src} NAME_WE)
-
-    add_executable(${example_name} ${example_src})
-
-    target_include_directories(${example_name} PRIVATE ${PROJECT_INCLUDE_DIRS})
-    
-    if(COMMON_WARN_FLAGS)
-        target_compile_options(${example_name} PRIVATE ${COMMON_WARN_FLAGS})
-    endif()
-
-    target_link_directories(${example_name} PRIVATE ${PROJECT_LIBRARY_DIRS})
-    target_compile_definitions(${example_name} PRIVATE ${PROJECT_DEFINES})
-    target_link_libraries(${example_name} PRIVATE ${PROJECT_LIBS})
-    
-    # Только под Windows: линковка с ws2_32 для NtpClient
-    if(WIN32)
-        target_link_libraries(${example_name} PRIVATE ws2_32)
-    endif()
-    
-    # Добавляем заголовки как SOURCES (чтобы IDE показывала их)
-    set_source_files_properties(${PROJECT_HEADERS} PROPERTIES HEADER_FILE_ONLY ON)
-    target_sources(${example_name} PRIVATE ${PROJECT_HEADERS})
-    
-    foreach(dll ${DLL_FILES})
-        add_custom_command(TARGET ${example_name} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            "${dll}"
-            "$<TARGET_FILE_DIR:${example_name}>"
-        )
+if(TIME_SHIELD_CPP_BUILD_EXAMPLES)
+    file(GLOB EXAMPLES_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} examples/*.cpp)
+    foreach(example_src ${EXAMPLES_SOURCES})
+        get_filename_component(example_name ${example_src} NAME_WE)
+        add_executable(${example_name} ${example_src})
+        target_link_libraries(${example_name} PRIVATE time_shield_cpp::time_shield_cpp)
+        if(COMMON_WARN_FLAGS)
+            target_compile_options(${example_name} PRIVATE ${COMMON_WARN_FLAGS})
+        endif()
+        if(WIN32 AND example_name STREQUAL "ntp_client_example")
+            target_link_libraries(${example_name} PRIVATE ws2_32)
+        endif()
+        set_source_files_properties(${PROJECT_HEADERS} PROPERTIES HEADER_FILE_ONLY ON)
+        target_sources(${example_name} PRIVATE ${PROJECT_HEADERS})
     endforeach()
-endforeach()
+endif()
+
+if(TIME_SHIELD_CPP_BUILD_TESTS)
+    enable_testing()
+    file(GLOB TEST_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tests/*.cpp)
+    foreach(test_src ${TEST_SOURCES})
+        get_filename_component(test_name ${test_src} NAME_WE)
+        add_executable(${test_name} ${test_src})
+        target_link_libraries(${test_name} PRIVATE time_shield_cpp::time_shield_cpp)
+        if(COMMON_WARN_FLAGS)
+            target_compile_options(${test_name} PRIVATE ${COMMON_WARN_FLAGS})
+        endif()
+        add_test(NAME ${test_name} COMMAND ${test_name})
+    endforeach()
+endif()

--- a/cmake/time_shield_cppConfig.cmake.in
+++ b/cmake/time_shield_cppConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/time_shield_cppTargets.cmake")

--- a/tests/time_zone_struct_test.cpp
+++ b/tests/time_zone_struct_test.cpp
@@ -1,0 +1,15 @@
+#include <time_shield/time_zone_struct.hpp>
+#include <cassert>
+
+/// \brief Basic checks for time zone conversion helpers.
+int main() {
+    using namespace time_shield;
+
+    TimeZoneStruct tz = create_time_zone_struct(3, 0, true);
+    assert(time_zone_struct_to_offset(tz) == 3 * SEC_PER_HOUR);
+
+    tz = create_time_zone_struct(5, 30, false);
+    assert(time_zone_struct_to_offset(tz) == -(5 * SEC_PER_HOUR + 30 * SEC_PER_MIN));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose `time_shield_cpp` as an interface library with install and package config support
- add a basic test exercising time zone helpers
- add GitHub Actions workflow building and testing on Linux, Windows and macOS for C++11 and C++17

## Testing
- `cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=11`
- `cmake --build build`
- `ctest --test-dir build`
- `cmake -S . -B build17 -DTIME_SHIELD_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=17`
- `cmake --build build17`
- `ctest --test-dir build17`


------
https://chatgpt.com/codex/tasks/task_e_68c088618e44832cb5b9894d67068ade