### PR TITLE
Improve build scripts and add POSIX example builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,13 @@ include the main file:
 #include <time_shield.hpp>
 ```
 
-Examples can be built with the `build-examples.bat` script. Use
-`install_mql5.bat` to install the MQL5 files.
+Examples can be built with the provided scripts:
+
+- `build-examples.bat` for Windows;
+- `build_examples.sh` for Linux/macOS;
+- `build-cb.bat` to generate a Code::Blocks project.
+
+Use `install_mql5.bat` to install the MQL5 files.
 
 ## Usage Examples
 

--- a/build-cb.bat
+++ b/build-cb.bat
@@ -1,3 +1,12 @@
+@echo off
 mkdir build-cb
-cmake -G "CodeBlocks - MinGW Makefiles" -S . -B build-cb
+cmake -G "CodeBlocks - MinGW Makefiles" -S . -B build-cb || goto :error
+goto :done
+
+:error
+echo CMake generation failed.
+pause
+exit /b 1
+
+:done
 pause

--- a/build-examples.bat
+++ b/build-examples.bat
@@ -1,4 +1,13 @@
+@echo off
 mkdir build
-cmake -S . -B build -DCMAKE_CXX_STANDARD=17 > log.txt 2>&1
-cmake --build build >> log.txt 2>&1
+cmake -S . -B build -DCMAKE_CXX_STANDARD=17 > log.txt 2>&1 || goto :error
+cmake --build build >> log.txt 2>&1 || goto :error
+goto :done
+
+:error
+echo Build failed. See log.txt for details.
+pause
+exit /b 1
+
+:done
 pause

--- a/build_examples.sh
+++ b/build_examples.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+mkdir -p build
+cmake -S . -B build -DCMAKE_CXX_STANDARD=17 > log.txt 2>&1 || { echo "CMake configuration failed. See log.txt for details." >&2; exit 1; }
+cmake --build build >> log.txt 2>&1 || { echo "Build failed. See log.txt for details." >&2; exit 1; }
+


### PR DESCRIPTION
## Summary
- add error handling and trailing newlines to batch build scripts
- add `build_examples.sh` for Linux/macOS users
- document build script usage in the README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68c093f6ba0c832c950bfe909f243cfe