### PR TITLE
ci: skip docs publish when no changes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,8 +25,8 @@ jobs:
       - name: Generate Documentation
         uses: mattnotmitt/doxygen-action@edge
       - name: Publish generated content to GitHub Pages
-        uses: tsunematsu21/actions-publish-gh-pages@v1.0.2
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          dir: docs/html
-          branch: gh-pages
-          token: ${{ secrets.ACCESS_TOKEN }}
+          github_token: ${{ secrets.ACCESS_TOKEN }}
+          publish_dir: docs/html
+          publish_branch: gh-pages


### PR DESCRIPTION
## Summary
- avoid failing publish workflow when no docs updates

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c0af8d1af8832c89a51bb691232267