### PR TITLE
Rename project and library for CMake packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,51 +1,51 @@
 cmake_minimum_required(VERSION 3.18)
-project(time_shield_cpp VERSION 0.1.0 LANGUAGES CXX)
+project(TimeShield VERSION 0.1.0 LANGUAGES CXX)
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 11)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-add_library(time_shield_cpp INTERFACE)
-add_library(time_shield_cpp::time_shield_cpp ALIAS time_shield_cpp)
+add_library(time_shield INTERFACE)
+add_library(time_shield::time_shield ALIAS time_shield)
 
-target_compile_features(time_shield_cpp INTERFACE cxx_std_11)
+target_compile_features(time_shield INTERFACE cxx_std_11)
 
 target_include_directories(
-    time_shield_cpp
+    time_shield
     INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/time_shield_cpp>
-        $<INSTALL_INTERFACE:include/time_shield_cpp>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/time_shield_cpp>
 )
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-install(TARGETS time_shield_cpp EXPORT time_shield_cppTargets)
+install(TARGETS time_shield EXPORT TimeShieldTargets)
 install(DIRECTORY include/time_shield_cpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(
-    EXPORT time_shield_cppTargets
-    FILE time_shield_cppTargets.cmake
-    NAMESPACE time_shield_cpp::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/time_shield_cpp
+    EXPORT TimeShieldTargets
+    FILE TimeShieldTargets.cmake
+    NAMESPACE time_shield::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/TimeShield
 )
 
 configure_package_config_file(
-    cmake/time_shield_cppConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/time_shield_cppConfig.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/time_shield_cpp
+    cmake/TimeShieldConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/TimeShieldConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/TimeShield
 )
 
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/time_shield_cppConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/TimeShieldConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY SameMajorVersion
 )
 
 install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/time_shield_cppConfig.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/time_shield_cppConfigVersion.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/time_shield_cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/TimeShieldConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/TimeShieldConfigVersion.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/TimeShield
 )
 
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
@@ -73,7 +73,7 @@ if(TIME_SHIELD_CPP_BUILD_EXAMPLES)
     foreach(example_src ${EXAMPLES_SOURCES})
         get_filename_component(example_name ${example_src} NAME_WE)
         add_executable(${example_name} ${example_src})
-        target_link_libraries(${example_name} PRIVATE time_shield_cpp::time_shield_cpp)
+        target_link_libraries(${example_name} PRIVATE time_shield::time_shield)
         if(COMMON_WARN_FLAGS)
             target_compile_options(${example_name} PRIVATE ${COMMON_WARN_FLAGS})
         endif()
@@ -91,7 +91,7 @@ if(TIME_SHIELD_CPP_BUILD_TESTS)
     foreach(test_src ${TEST_SOURCES})
         get_filename_component(test_name ${test_src} NAME_WE)
         add_executable(${test_name} ${test_src})
-        target_link_libraries(${test_name} PRIVATE time_shield_cpp::time_shield_cpp)
+        target_link_libraries(${test_name} PRIVATE time_shield::time_shield)
         if(COMMON_WARN_FLAGS)
             target_compile_options(${test_name} PRIVATE ${COMMON_WARN_FLAGS})
         endif()

--- a/README.md
+++ b/README.md
@@ -56,11 +56,16 @@ more academic solutions like `HowardHinnant/date`, the library:
 
 ## Installation and Setup
 
-The library comes as headers. Add `include/time_shield_cpp` to your project and
-include the main file:
+The library is header-only and can be consumed with CMake:
 
-```cpp
-#include <time_shield.hpp>
+```cmake
+cmake_minimum_required(VERSION 3.18)
+project(app LANGUAGES CXX)
+
+find_package(TimeShield CONFIG REQUIRED)
+
+add_executable(app main.cpp)
+target_link_libraries(app PRIVATE time_shield::time_shield)
 ```
 
 Examples can be built with the provided scripts:

--- a/cmake/TimeShieldConfig.cmake.in
+++ b/cmake/TimeShieldConfig.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/TimeShieldTargets.cmake")

--- a/cmake/time_shield_cppConfig.cmake.in
+++ b/cmake/time_shield_cppConfig.cmake.in
@@ -1,3 +1,0 @@
-@PACKAGE_INIT@
-
-include("${CMAKE_CURRENT_LIST_DIR}/time_shield_cppTargets.cmake")


### PR DESCRIPTION
## Summary
- rename project to `TimeShield` and library target to `time_shield`
- install headers and CMake package config to `lib/cmake/TimeShield`
- document `find_package(TimeShield)` usage in README

## Testing
- `cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_EXAMPLES=OFF -DTIME_SHIELD_CPP_BUILD_TESTS=ON`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68c0b4a272d4832c9171dbc19641a40f