### PR TITLE
Add vcpkg overlay port

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,22 @@ add_executable(app main.cpp)
 target_link_libraries(app PRIVATE time_shield::time_shield)
 ```
 
+### vcpkg
+
+Install via a local overlay port:
+
+```sh
+vcpkg install time-shield-cpp --overlay-ports=./vcpkg-overlay/ports
+```
+
+Use the vcpkg toolchain when configuring CMake:
+
+```sh
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake
+```
+
+The port is intended to be upstreamed to [microsoft/vcpkg](https://github.com/microsoft/vcpkg).
+
 Examples can be built with the provided scripts:
 
 - `build-examples.bat` for Windows;

--- a/vcpkg-overlay/ports/time-shield-cpp/portfile.cmake
+++ b/vcpkg-overlay/ports/time-shield-cpp/portfile.cmake
@@ -1,0 +1,21 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NewYaroslav/time-shield-cpp
+    REF v1.0.2
+    SHA512 cbd0a981af568ca41d9350911f71535b8c7ed4466b36bbc9ceff9c33e0d9f2ed22ca86950836836ca7c2997f316b7612efa9234225bc41f2f0e5e9c5119358b4
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME TimeShield
+)
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME LICENSE)
+file(INSTALL ${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT})
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug)

--- a/vcpkg-overlay/ports/time-shield-cpp/vcpkg.json
+++ b/vcpkg-overlay/ports/time-shield-cpp/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "time-shield-cpp",
+  "version": "1.0.2",
+  "description": "Header-only C++ library for time conversions, formatting, and utilities.",
+  "homepage": "https://github.com/NewYaroslav/time-shield-cpp",
+  "license": "MIT"
+}


### PR DESCRIPTION
## Summary
- add vcpkg overlay for time-shield-cpp with portfile and metadata
- document vcpkg installation and toolchain usage

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c0c0f8ba6c832cb0f9d8f558f6fed2