### PR TITLE
fix: include umbrella header in installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 install(TARGETS time_shield EXPORT TimeShieldTargets)
-install(DIRECTORY include/time_shield DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES include/time_shield.hpp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(
     EXPORT TimeShieldTargets
     FILE TimeShieldTargets.cmake
@@ -40,7 +39,7 @@ configure_package_config_file(
 write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/TimeShieldConfigVersion.cmake
     VERSION ${PROJECT_VERSION}
-    COMPATIBILITY SameMajorVersion
+    COMPATIBILITY SameMinorVersion
 )
 
 install(FILES


### PR DESCRIPTION
## Summary
- ensure entire header tree, including umbrella header, is installed
- tighten package versioning to SameMinorVersion

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest`

------
https://chatgpt.com/codex/tasks/task_e_68c208637fd4832caa4e578340ae249f