### PR TITLE
Add installation verification and consumer build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,14 @@ jobs:
         run: cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
       - name: Build
         run: cmake --build build
+      - name: Install
+        run: cmake --install build --prefix install
       - name: Test
         run: ctest --test-dir build
+      - name: Configure consumer project
+        run: cmake -S tests/install_consumer -B build-consumer -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build consumer project
+        run: cmake --build build-consumer
 
   windows:
     runs-on: windows-latest
@@ -32,8 +38,14 @@ jobs:
         run: cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
       - name: Build
         run: cmake --build build --config Release
+      - name: Install
+        run: cmake --install build --prefix install --config Release
       - name: Test
         run: ctest --test-dir build -C Release
+      - name: Configure consumer project
+        run: cmake -S tests/install_consumer -B build-consumer -DCMAKE_PREFIX_PATH="${{ github.workspace }}/install" -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build consumer project
+        run: cmake --build build-consumer --config Release
 
   macos:
     runs-on: macos-latest
@@ -46,8 +58,14 @@ jobs:
         run: cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
       - name: Build
         run: cmake --build build
+      - name: Install
+        run: cmake --install build --prefix install
       - name: Test
         run: ctest --test-dir build
+      - name: Configure consumer project
+        run: cmake -S tests/install_consumer -B build-consumer -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build consumer project
+        run: cmake --build build-consumer
 
   vcpkg-install:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ target_include_directories(
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-install(TARGETS time_shield EXPORT TimeShieldTargets)
+install(TARGETS time_shield EXPORT TimeShieldTargets
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(
     EXPORT TimeShieldTargets

--- a/tests/install_consumer/CMakeLists.txt
+++ b/tests/install_consumer/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.18)
+project(InstallConsumer LANGUAGES CXX)
+
+find_package(TimeShield CONFIG REQUIRED)
+
+add_executable(install_consumer consumer.cpp)
+target_link_libraries(install_consumer PRIVATE time_shield::time_shield)

--- a/tests/install_consumer/consumer.cpp
+++ b/tests/install_consumer/consumer.cpp
@@ -1,0 +1,7 @@
+#include <time_shield/time_utils.hpp>
+
+/// \brief Verify library usage from an installed location.
+int main() {
+    const auto current_ts = time_shield::now();
+    return current_ts > 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- run `cmake --install` in CI and build a small consumer to ensure exported targets work
- expose include directories when installing TimeShield
- add a minimal consumer project using `find_package(TimeShield)`

## Testing
- `cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON`
- `cmake --build build`
- `cmake --install build --prefix install`
- `ctest --test-dir build`
- `cmake -S tests/install_consumer -B build-consumer -DCMAKE_PREFIX_PATH=$(pwd)/install`
- `cmake --build build-consumer`


------
https://chatgpt.com/codex/tasks/task_e_68c20fb34dc8832c87f5790e9299370c