### PR TITLE
Lower required CMake version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.15)
 project(TimeShield VERSION 1.0.3 LANGUAGES CXX)
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ After installing the library (e.g., with `cmake --install`), consume it in a
 project with CMake:
 
 ```cmake
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.15)
 project(app LANGUAGES CXX)
 
 find_package(TimeShield CONFIG REQUIRED)

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -94,7 +94,7 @@ After installing the library (e.g., via `cmake --install`), locate it with
 `find_package`:
 
 \code{.cmake}
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.15)
 project(app LANGUAGES CXX)
 
 find_package(TimeShield CONFIG REQUIRED)

--- a/tests/install_consumer/CMakeLists.txt
+++ b/tests/install_consumer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.15)
 project(InstallConsumer LANGUAGES CXX)
 
 find_package(TimeShield CONFIG REQUIRED)


### PR DESCRIPTION
## Summary
- Reduce CMake minimum version from 3.18 to 3.15 in build files and docs
- Confirm project uses only features available in CMake 3.15 or older

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68c21228a980832c93117026bb384152