### PR TITLE
feat(cmake): add NTP client install toggle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,26 @@ target_include_directories(
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
+if(WIN32)
+    set(TIME_SHIELD_ENABLE_NTP_CLIENT_DEFAULT ON)
+else()
+    set(TIME_SHIELD_ENABLE_NTP_CLIENT_DEFAULT OFF)
+endif()
+option(TIME_SHIELD_ENABLE_NTP_CLIENT "Enable NTP client" ${TIME_SHIELD_ENABLE_NTP_CLIENT_DEFAULT})
+
+target_compile_definitions(
+    time_shield
+    INTERFACE
+        TIME_SHIELD_ENABLE_NTP_CLIENT=$<BOOL:${TIME_SHIELD_ENABLE_NTP_CLIENT}>
+)
+
 install(TARGETS time_shield EXPORT TimeShieldTargets
     INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if(TIME_SHIELD_ENABLE_NTP_CLIENT)
+    install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+else()
+    install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} PATTERN "ntp_client*" EXCLUDE)
+endif()
 install(
     EXPORT TimeShieldTargets
     FILE TimeShieldTargets.cmake

--- a/include/time_shield.hpp
+++ b/include/time_shield.hpp
@@ -24,7 +24,9 @@
 #include "time_shield/time_zone_conversions.hpp"   ///< Functions for converting between time zones.
 #include "time_shield/time_formatting.hpp"         ///< Functions for formatting time in various standard formats.
 #include "time_shield/time_parser.hpp"             ///< Functions for parsing time in various standard formats.
-#include "time_shield/ntp_client.hpp"              ///< NTP client for time offset queries.
+#if TIME_SHIELD_ENABLE_NTP_CLIENT
+#   include "time_shield/ntp_client.hpp"              ///< NTP client for time offset queries.
+#endif
 #include "time_shield/initialization.hpp"          ///< Library initialization helpers.
 
 /// \namespace tsh


### PR DESCRIPTION
## Summary
- add `TIME_SHIELD_ENABLE_NTP_CLIENT` CMake option
- skip installing NTP client headers when disabled
- wrap NTP client include in umbrella header

## Testing
- `cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c21cec1248832c830d384a6c699be6