### PR TITLE
test: add leap-year and boundary parsing tests

### DIFF
--- a/tests/iso8601_negative_test.cpp
+++ b/tests/iso8601_negative_test.cpp
@@ -12,6 +12,12 @@ int main() {
     is_valid = str_to_ts("2023-02-30T00:00:00Z", parsed);
     assert(!is_valid);
 
+    is_valid = str_to_ts("2023-02-29T00:00:00Z", parsed);
+    assert(!is_valid);
+
+    is_valid = str_to_ts("2023-04-31T00:00:00Z", parsed);
+    assert(!is_valid);
+
     is_valid = str_to_ts("2023-01-01T24:00:00Z", parsed);
     assert(!is_valid);
 

--- a/tests/time_boundaries_test.cpp
+++ b/tests/time_boundaries_test.cpp
@@ -17,9 +17,13 @@ int main() {
     ts_t may_start = ts("2023-05-01T00:00:00Z");
     assert(apr_end + 1 == may_start);
 
+    ts_t dec_start = ts("2023-12-31T00:00:00Z");
     ts_t dec_end = ts("2023-12-31T23:59:59Z");
     ts_t jan_start = ts("2024-01-01T00:00:00Z");
+    ts_t jan_end = ts("2024-01-01T23:59:59Z");
     assert(dec_end + 1 == jan_start);
+    assert(dec_start + SEC_PER_DAY == jan_start);
+    assert(dec_end + SEC_PER_DAY == jan_end);
 
     ts_t start_day = ts("2020-01-01T00:00:00Z");
     ts_t end_day = ts("2020-01-01T23:59:59Z");


### PR DESCRIPTION
## Summary
- test Feb 29 on non-leap year and April 31 parsing failures
- check year transitions at 00:00:00 and 23:59:59

## Testing
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68c227baa054832c9b560360c5518e09