### PR TITLE
Add DST end tests and GMT conversion helpers

### DIFF
--- a/include/time_shield/time_zone_conversions.hpp
+++ b/include/time_shield/time_zone_conversions.hpp
@@ -94,6 +94,48 @@ namespace time_shield {
         return cet_to_gmt(eet - SEC_PER_HOUR);
     }
 
+    /// \brief Convert Greenwich Mean Time to Central European Time.
+    /// \param gmt Timestamp in seconds in GMT.
+    /// \return Timestamp in seconds in CET.
+    inline ts_t gmt_to_cet(ts_t gmt) {
+        DateTimeStruct dt = to_date_time(gmt);
+        const int SWITCH_HOUR = 1;
+
+        if(dt.mon > MAR && dt.mon < OCT) {
+            return gmt + SEC_PER_HOUR * 2;
+        } else if(dt.mon == MAR) {
+            int last = last_sunday_month_day(dt.year, MAR);
+            if(dt.day > last) {
+                return gmt + SEC_PER_HOUR * 2;
+            } else if(dt.day < last) {
+                return gmt + SEC_PER_HOUR;
+            } else {
+                if(dt.hour >= SWITCH_HOUR)
+                    return gmt + SEC_PER_HOUR * 2;
+                return gmt + SEC_PER_HOUR;
+            }
+        } else if(dt.mon == OCT) {
+            int last = last_sunday_month_day(dt.year, OCT);
+            if(dt.day > last) {
+                return gmt + SEC_PER_HOUR;
+            } else if(dt.day < last) {
+                return gmt + SEC_PER_HOUR * 2;
+            } else {
+                if(dt.hour >= SWITCH_HOUR)
+                    return gmt + SEC_PER_HOUR;
+                return gmt + SEC_PER_HOUR * 2;
+            }
+        }
+        return gmt + SEC_PER_HOUR;
+    }
+
+    /// \brief Convert Greenwich Mean Time to Eastern European Time.
+    /// \param gmt Timestamp in seconds in GMT.
+    /// \return Timestamp in seconds in EET.
+    inline ts_t gmt_to_eet(ts_t gmt) {
+        return gmt_to_cet(gmt) + SEC_PER_HOUR;
+    }
+
     /// \}
 
 } // namespace time_shield

--- a/tests/gmt_time_zone_conversion_test.cpp
+++ b/tests/gmt_time_zone_conversion_test.cpp
@@ -1,0 +1,48 @@
+#include <time_shield/time_zone_conversions.hpp>
+#include <time_shield/time_conversions.hpp>
+#include <cassert>
+
+/// \brief Round-trip tests for GMT and CET/EET conversions around DST boundaries.
+int main() {
+    using namespace time_shield;
+
+    for(int year : {2021, 2022, 2023, 2024}) {
+        int start_day = last_sunday_month_day(year, MAR);
+
+        ts_t cet_start_before = to_timestamp(year, int(MAR), start_day, 1, 59, 0);
+        ts_t gmt_from_cet_before = cet_to_gmt(cet_start_before);
+        assert(gmt_to_cet(gmt_from_cet_before) == cet_start_before);
+
+        ts_t cet_start_after = to_timestamp(year, int(MAR), start_day, 3, 0, 0);
+        ts_t gmt_from_cet_after = cet_to_gmt(cet_start_after);
+        assert(gmt_to_cet(gmt_from_cet_after) == cet_start_after);
+
+        ts_t eet_start_before = to_timestamp(year, int(MAR), start_day, 2, 59, 0);
+        ts_t gmt_from_eet_before = eet_to_gmt(eet_start_before);
+        assert(gmt_to_eet(gmt_from_eet_before) == eet_start_before);
+
+        ts_t eet_start_after = to_timestamp(year, int(MAR), start_day, 4, 0, 0);
+        ts_t gmt_from_eet_after = eet_to_gmt(eet_start_after);
+        assert(gmt_to_eet(gmt_from_eet_after) == eet_start_after);
+
+        int end_day = last_sunday_month_day(year, OCT);
+
+        ts_t cet_end_before = to_timestamp(year, int(OCT), end_day, 1, 59, 0);
+        ts_t gmt_from_cet_end_before = cet_to_gmt(cet_end_before);
+        assert(gmt_to_cet(gmt_from_cet_end_before) == cet_end_before);
+
+        ts_t cet_end_after = to_timestamp(year, int(OCT), end_day, 3, 0, 0);
+        ts_t gmt_from_cet_end_after = cet_to_gmt(cet_end_after);
+        assert(gmt_to_cet(gmt_from_cet_end_after) == cet_end_after);
+
+        ts_t eet_end_before = to_timestamp(year, int(OCT), end_day, 3, 59, 0);
+        ts_t gmt_from_eet_end_before = eet_to_gmt(eet_end_before);
+        assert(gmt_to_eet(gmt_from_eet_end_before) == eet_end_before);
+
+        ts_t eet_end_after = to_timestamp(year, int(OCT), end_day, 4, 0, 0);
+        ts_t gmt_from_eet_end_after = eet_to_gmt(eet_end_after);
+        assert(gmt_to_eet(gmt_from_eet_end_after) == eet_end_after);
+    }
+
+    return 0;
+}

--- a/tests/time_zone_conversion_test.cpp
+++ b/tests/time_zone_conversion_test.cpp
@@ -35,5 +35,25 @@ int main() {
     ts_t gmt_eet_summer = eet_to_gmt(eet_summer);
     assert(gmt_eet_summer == to_timestamp(2023, 7, 1, 9, 0, 0));
 
+    for(int year : {2021, 2022, 2023, 2024}) {
+        int day = last_sunday_month_day(year, OCT);
+
+        ts_t cet_end_before = to_timestamp(year, int(OCT), day, 1, 30, 0);
+        ts_t gmt_end_before = cet_to_gmt(cet_end_before);
+        assert(gmt_end_before == to_timestamp(year, int(OCT), day - 1, 23, 30, 0));
+
+        ts_t cet_end_after = to_timestamp(year, int(OCT), day, 3, 30, 0);
+        ts_t gmt_end_after = cet_to_gmt(cet_end_after);
+        assert(gmt_end_after == to_timestamp(year, int(OCT), day, 2, 30, 0));
+
+        ts_t eet_end_before = to_timestamp(year, int(OCT), day, 2, 30, 0);
+        ts_t gmt_eet_end_before = eet_to_gmt(eet_end_before);
+        assert(gmt_eet_end_before == to_timestamp(year, int(OCT), day - 1, 23, 30, 0));
+
+        ts_t eet_end_after = to_timestamp(year, int(OCT), day, 4, 30, 0);
+        ts_t gmt_eet_end_after = eet_to_gmt(eet_end_after);
+        assert(gmt_eet_end_after == to_timestamp(year, int(OCT), day, 2, 30, 0));
+    }
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `gmt_to_cet` and `gmt_to_eet` helpers for reverse timezone conversion
- cover CET/EET autumn DST transitions across multiple years
- ensure GMT round-trip symmetry around DST boundaries

## Testing
- `for file in tests/*_test.cpp; do echo "Compiling $file"; g++ -std=c++20 -Iinclude $file -o /tmp/$(basename $file .cpp) && /tmp/$(basename $file .cpp) || break; done`


------
https://chatgpt.com/codex/tasks/task_e_68c22ea29708832c8559e61d67beb42f