### PR TITLE
test(install): add warnings to consumer

### DIFF
--- a/tests/install_consumer/CMakeLists.txt
+++ b/tests/install_consumer/CMakeLists.txt
@@ -5,3 +5,9 @@ find_package(TimeShield CONFIG REQUIRED)
 
 add_executable(install_consumer consumer.cpp)
 target_link_libraries(install_consumer PRIVATE time_shield::time_shield)
+
+if(MSVC)
+    target_compile_options(install_consumer PRIVATE /W4)
+else()
+    target_compile_options(install_consumer PRIVATE -Wall -Wextra -Wpedantic)
+endif()


### PR DESCRIPTION
## Summary
- verify installed package by building a consumer with `find_package(TimeShield CONFIG REQUIRED)`
- build consumer project with `/W4` on MSVC and `-Wall -Wextra -Wpedantic` elsewhere

## Testing
- `cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON`
- `cmake --build build`
- `cmake --install build --prefix install`
- `ctest --test-dir build`
- `cmake -S tests/install_consumer -B build-consumer -DCMAKE_PREFIX_PATH=$(pwd)/install`
- `cmake --build build-consumer -- VERBOSE=1`

------
https://chatgpt.com/codex/tasks/task_e_68c2396aa8a0832c9a9e34c4a0073136