### PR TITLE
docs: add changelog and versioning policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [v1.0.3] - 2025-09-10
+- Added pkg-config template and vcpkg overlay port.
+- Added optional NTP client install toggle and configuration flags.
+- Expanded time parser tests and DST boundary coverage.
+- Lowered minimum required CMake version to 3.15.
+- Improved installation and consumer build scripts.
+
+## [v1.0.2] - 2025-07-20
+- Removed invalid const qualifiers from return types in time utilities.
+- Fixed compiler warnings and added dt_to_timestamp example.
+
+## [v1.0.1] - 2025-06-25
+- Optimized sec_of_day and other parsing helpers.
+- Added WinSock-based NtpClient and timezone conversion utilities.
+- Provided usage examples and expanded documentation.
+
+## [v1.0.0] - 2025-06-21
+- Initial release with MQL5 Unix year helpers.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Use `time_shield::` or `using namespace time_shield;` to access the API.
 - Core functions avoid throwing exceptions and do not allocate dynamic memory;
   helpers returning `std::string` rely on the caller to manage allocations.
 
+## Versioning
+
+Time Shield follows [Semantic Versioning](https://semver.org). Patch releases
+contain only backward-compatible fixes. Minor versions add
+backward-compatible features. Major versions may include breaking changes. The
+public API comprises headers under `include/time_shield`.
+
 ## Installation
 
 ### Install and `find_package`


### PR DESCRIPTION
## Summary
- document project history in CHANGELOG for v1.0.0–v1.0.3
- describe Semantic Versioning policy in README

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c35d7130e0832cba37b123dccef53a