### PR TITLE
fix: handle negative ISO8601 offsets

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -91,7 +91,7 @@ std::string filename = to_windows_filename(now);
 
 DateTimeStruct dt;
 TimeZoneStruct tz;
-if (parse_iso8601("2024-11-25T14:30:00+01:00", dt, tz)) {
+if (parse_iso8601("2024-11-25T14:30:00-05:30", dt, tz)) {
     ts_t ts_val = to_timestamp(dt) + to_offset(tz);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ std::string filename = to_windows_filename(now);
 
 DateTimeStruct dt;
 TimeZoneStruct tz;
-if (parse_iso8601("2024-11-25T14:30:00+01:00", dt, tz)) {
+if (parse_iso8601("2024-11-25T14:30:00-05:30", dt, tz)) {
     ts_t ts_val = to_timestamp(dt) + to_offset(tz);
 }
 ```

--- a/examples/time_parser_example.cpp
+++ b/examples/time_parser_example.cpp
@@ -12,7 +12,7 @@
 int main() {
     using namespace time_shield;
 
-    const std::string iso = "2024-11-25T14:30:00+01:00";
+    const std::string iso = "2024-11-25T14:30:00-05:30";
 
     DateTimeStruct dt;
     TimeZoneStruct tz;

--- a/include/time_shield/time_conversions.hpp
+++ b/include/time_shield/time_conversions.hpp
@@ -1863,7 +1863,7 @@ namespace time_shield {
         T tz;
         int abs_val = std::abs(offset);
         tz.hour = abs_val / SEC_PER_HOUR;
-        tz.min = abs_val % SEC_PER_MIN;
+        tz.min = (abs_val % SEC_PER_HOUR) / SEC_PER_MIN;
         tz.is_positive = (offset >= 0);
         return tz;
     }

--- a/include/time_shield/time_zone_struct.hpp
+++ b/include/time_shield/time_zone_struct.hpp
@@ -45,7 +45,7 @@ namespace time_shield {
     inline TimeZoneStruct to_time_zone_struct(tz_t offset) {
         int abs_val = std::abs(offset);
         int hour = abs_val / SEC_PER_HOUR;
-        int min = abs_val % SEC_PER_MIN;
+        int min = (abs_val % SEC_PER_HOUR) / SEC_PER_MIN;
         bool is_positive = (offset >= 0);
         return TimeZoneStruct{hour, min, is_positive};
     }

--- a/tests/iso8601_round_trip_test.cpp
+++ b/tests/iso8601_round_trip_test.cpp
@@ -20,7 +20,7 @@ int main() {
     const tz_t offset_neg = -(5 * SEC_PER_HOUR + 30 * SEC_PER_MIN);
     std::string str_neg = to_iso8601(base_ts - offset_neg, offset_neg);
     ts_t parsed_neg = ts(str_neg);
-    assert(parsed_neg != base_ts);
+    assert(parsed_neg == base_ts);
 
     const ts_ms_t base_ms = ts_ms(2024, 3, 20, 12, 34, 56, 789);
     std::string str_ms = to_iso8601_ms(base_ms);
@@ -37,7 +37,7 @@ int main() {
 
     std::string str_ms_neg = to_iso8601_ms(base_ms - sec_to_ms(offset_neg), offset_neg);
     ts_ms_t parsed_ms_neg = ts_ms(str_ms_neg);
-    assert(parsed_ms_neg != base_ms);
+    assert(parsed_ms_neg == base_ms);
 
     ts_ms_t parsed_fail = 0;
     bool is_ok = str_to_ts_ms("2024-03-20T12:34:56.789123Z", parsed_fail);


### PR DESCRIPTION
## Summary
- handle minute component when converting timezone offsets
- ensure negative ISO8601 offsets round-trip correctly in tests
- document parsing of ISO8601 strings with negative offsets

## Testing
- `g++ -std=c++17 -Iinclude tests/iso8601_round_trip_test.cpp -o /tmp/iso8601_rt_test && /tmp/iso8601_rt_test`

------
https://chatgpt.com/codex/tasks/task_e_68c364f0f424832c892ff4b0064920bb