### PR TITLE
chore(repo): add export-ignore for source archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Не включать эти папки в GitHub source archive (tar.gz/zip)
+vcpkg-overlay/ export-ignore
+.github/       export-ignore


### PR DESCRIPTION
## Summary
- exclude vcpkg-overlay and .github directories from generated source archives

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68c3882d680c832caa65e4d5236ead84