### PR TITLE
chore: release 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.0.4] - 2025-09-20
+- Synchronized project metadata to release version 1.0.4 across build and packaging files.
+
 ## [v1.0.3] - 2025-09-10
 - Added pkg-config template and vcpkg overlay port.
 - Added optional NTP client install toggle and configuration flags.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(TimeShield VERSION 1.0.3 LANGUAGES CXX)
+project(TimeShield VERSION 1.0.4 LANGUAGES CXX)
 
 if(NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 11)

--- a/vcpkg-overlay/ports/time-shield-cpp/vcpkg.json
+++ b/vcpkg-overlay/ports/time-shield-cpp/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "time-shield-cpp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Header-only C++ library for time conversions, formatting, and utilities.",
   "homepage": "https://github.com/NewYaroslav/time-shield-cpp",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump project version metadata to 1.0.4
- document the 1.0.4 release notes in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce1dcc57b8832c99adf268e412a29d