### PR TITLE
fix: align 64-bit format specifiers with inttypes macros

### DIFF
--- a/include/time_shield/time_formatting.hpp
+++ b/include/time_shield/time_formatting.hpp
@@ -10,6 +10,8 @@
 /// It provides utilities for custom formatting based on user-defined patterns
 /// and for standard date-time string representations.
 
+#include <inttypes.h>
+
 #include "date_time_struct.hpp"
 #include "time_zone_struct.hpp"
 #include "time_conversions.hpp"
@@ -129,9 +131,9 @@ namespace time_shield {
                     snprintf(buffer, sizeof(buffer), "%.4d-%.2d-%.2d", (int)dt.year, dt.mon, dt.day);
                 } else
                 if (dt.year < 0) {
-                    snprintf(buffer, sizeof(buffer), "-%lld-%.2d-%.2d", dt.year, dt.mon, dt.day);
+                    snprintf(buffer, sizeof(buffer), "-%" PRId64 "-%.2d-%.2d", dt.year, dt.mon, dt.day);
                 } else {
-                    snprintf(buffer, sizeof(buffer), "+%lld-%.2d-%.2d", dt.year, dt.mon, dt.day);
+                    snprintf(buffer, sizeof(buffer), "+%" PRId64 "-%.2d-%.2d", dt.year, dt.mon, dt.day);
                 }
                 result += std::string(buffer);
             }
@@ -304,15 +306,31 @@ namespace time_shield {
                 const int64_t centuries = dt.year - mega_years * 1000000 - millennia * 1000;
                 if (mega_years) {
                     if (millennia) {
-                        snprintf(buffer, sizeof(buffer), "%lldM%lldK%.3lld", mega_years, std::abs(millennia), std::abs(centuries));
+                        snprintf(
+                                buffer,
+                                sizeof(buffer),
+                                "%" PRId64 "M%" PRId64 "K%.3" PRId64,
+                                mega_years,
+                                static_cast<int64_t>(std::abs(millennia)),
+                                static_cast<int64_t>(std::abs(centuries)));
                     } else {
-                        snprintf(buffer, sizeof(buffer), "%lldM%.3lld", mega_years, std::abs(centuries));
+                        snprintf(
+                                buffer,
+                                sizeof(buffer),
+                                "%" PRId64 "M%.3" PRId64,
+                                mega_years,
+                                static_cast<int64_t>(std::abs(centuries)));
                     }
                 } else
                 if (millennia) {
-                    snprintf(buffer, sizeof(buffer), "%lldK%.3lld", millennia, std::abs(centuries));
+                    snprintf(
+                            buffer,
+                            sizeof(buffer),
+                            "%" PRId64 "K%.3" PRId64,
+                            millennia,
+                            static_cast<int64_t>(std::abs(centuries)));
                 } else {
-                    snprintf(buffer, sizeof(buffer), "%.4lld", dt.year);
+                    snprintf(buffer, sizeof(buffer), "%.4" PRId64, dt.year);
                 }
                 result += std::string(buffer);
             } else
@@ -527,9 +545,28 @@ namespace time_shield {
         DateTimeStruct dt = to_date_time<DateTimeStruct>(ts);
         char buffer[32] = {0};
         if TIME_SHIELD_IF_CONSTEXPR (std::is_floating_point<T>::value) {
-            snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+            snprintf(
+                    buffer,
+                    sizeof(buffer),
+                    "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d",
+                    dt.year,
+                    dt.mon,
+                    dt.day,
+                    dt.hour,
+                    dt.min,
+                    dt.sec,
+                    dt.ms);
         } else {
-            snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+            snprintf(
+                    buffer,
+                    sizeof(buffer),
+                    "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d",
+                    dt.year,
+                    dt.mon,
+                    dt.day,
+                    dt.hour,
+                    dt.min,
+                    dt.sec);
         }
         return std::string(buffer);
     }
@@ -545,7 +582,13 @@ namespace time_shield {
     inline const std::string to_iso8601_date(T ts) {
         DateTimeStruct dt = to_date_time<DateTimeStruct>(ts);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2d", dt.year, dt.mon, dt.day);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 "-%.2d-%.2d",
+                dt.year,
+                dt.mon,
+                dt.day);
         return std::string(buffer);
     }
 
@@ -599,9 +642,28 @@ namespace time_shield {
         DateTimeStruct dt = to_date_time<DateTimeStruct>(ts);
         char buffer[32] = {0};
         if TIME_SHIELD_IF_CONSTEXPR (std::is_floating_point<T>::value) {
-            snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d.%.3dZ", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+            snprintf(
+                    buffer,
+                    sizeof(buffer),
+                    "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d.%.3dZ",
+                    dt.year,
+                    dt.mon,
+                    dt.day,
+                    dt.hour,
+                    dt.min,
+                    dt.sec,
+                    dt.ms);
         } else {
-            snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2dZ", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+            snprintf(
+                    buffer,
+                    sizeof(buffer),
+                    "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2dZ",
+                    dt.year,
+                    dt.mon,
+                    dt.day,
+                    dt.hour,
+                    dt.min,
+                    dt.sec);
         }
         return std::string(buffer);
     }
@@ -615,7 +677,17 @@ namespace time_shield {
     inline const std::string to_iso8601_utc_ms(ts_ms_t ts_ms) {
         DateTimeStruct dt = to_date_time_ms<DateTimeStruct>(ts_ms);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d.%.3dZ", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d.%.3dZ",
+                dt.year,
+                dt.mon,
+                dt.day,
+                dt.hour,
+                dt.min,
+                dt.sec,
+                dt.ms);
         return std::string(buffer);
     }
 
@@ -628,7 +700,17 @@ namespace time_shield {
     inline const std::string to_iso8601_ms(ts_ms_t ts_ms) {
         DateTimeStruct dt = to_date_time_ms<DateTimeStruct>(ts_ms);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d",
+                dt.year,
+                dt.mon,
+                dt.day,
+                dt.hour,
+                dt.min,
+                dt.sec,
+                dt.ms);
         return std::string(buffer);
     }
 
@@ -647,15 +729,61 @@ namespace time_shield {
         char buffer[32] = {0};
         if TIME_SHIELD_IF_CONSTEXPR (std::is_floating_point<T>::value) {
             if (tz.is_positive) {
-                snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d+%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms, tz.hour, tz.min);
+                snprintf(
+                        buffer,
+                        sizeof(buffer),
+                        "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d+%.2d:%.2d",
+                        dt.year,
+                        dt.mon,
+                        dt.day,
+                        dt.hour,
+                        dt.min,
+                        dt.sec,
+                        dt.ms,
+                        tz.hour,
+                        tz.min);
             } else {
-                snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d-%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms, tz.hour, tz.min);
+                snprintf(
+                        buffer,
+                        sizeof(buffer),
+                        "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d-%.2d:%.2d",
+                        dt.year,
+                        dt.mon,
+                        dt.day,
+                        dt.hour,
+                        dt.min,
+                        dt.sec,
+                        dt.ms,
+                        tz.hour,
+                        tz.min);
             }
         } else {
             if (tz.is_positive) {
-                snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d+%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, tz.hour, tz.min);
+                snprintf(
+                        buffer,
+                        sizeof(buffer),
+                        "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d+%.2d:%.2d",
+                        dt.year,
+                        dt.mon,
+                        dt.day,
+                        dt.hour,
+                        dt.min,
+                        dt.sec,
+                        tz.hour,
+                        tz.min);
             } else {
-                snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d-%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, tz.hour, tz.min);
+                snprintf(
+                        buffer,
+                        sizeof(buffer),
+                        "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d-%.2d:%.2d",
+                        dt.year,
+                        dt.mon,
+                        dt.day,
+                        dt.hour,
+                        dt.min,
+                        dt.sec,
+                        tz.hour,
+                        tz.min);
             }
         }
         return std::string(buffer);
@@ -673,9 +801,33 @@ namespace time_shield {
         DateTimeStruct dt = to_date_time_ms<DateTimeStruct>(ts_ms);
         char buffer[32] = {0};
         if (tz.is_positive) {
-            snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d+%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms, tz.hour, tz.min);
+            snprintf(
+                    buffer,
+                    sizeof(buffer),
+                    "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d+%.2d:%.2d",
+                    dt.year,
+                    dt.mon,
+                    dt.day,
+                    dt.hour,
+                    dt.min,
+                    dt.sec,
+                    dt.ms,
+                    tz.hour,
+                    tz.min);
         } else {
-            snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d-%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms, tz.hour, tz.min);
+            snprintf(
+                    buffer,
+                    sizeof(buffer),
+                    "%" PRId64 "-%.2d-%.2dT%.2d:%.2d:%.2d.%.3d-%.2d:%.2d",
+                    dt.year,
+                    dt.mon,
+                    dt.day,
+                    dt.hour,
+                    dt.min,
+                    dt.sec,
+                    dt.ms,
+                    tz.hour,
+                    tz.min);
         }
         return std::string(buffer);
     }
@@ -689,7 +841,16 @@ namespace time_shield {
     inline const std::string to_mql5_date_time(ts_t ts) {
         DateTimeStruct dt = to_date_time<DateTimeStruct>(ts);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld.%.2d.%.2d %.2d:%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 ".%.2d.%.2d %.2d:%.2d:%.2d",
+                dt.year,
+                dt.mon,
+                dt.day,
+                dt.hour,
+                dt.min,
+                dt.sec);
         return std::string(buffer);
     }
 
@@ -708,7 +869,13 @@ namespace time_shield {
     inline const std::string to_mql5_date(ts_t ts) {
         DateTimeStruct dt = to_date_time<DateTimeStruct>(ts);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld.%.2d.%.2d", dt.year, dt.mon, dt.day);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 ".%.2d.%.2d",
+                dt.year,
+                dt.mon,
+                dt.day);
         return std::string(buffer);
     }
 
@@ -731,7 +898,16 @@ namespace time_shield {
     inline const std::string to_windows_filename(ts_t ts) {
         DateTimeStruct dt = to_date_time<DateTimeStruct>(ts);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2d_%.2d-%.2d-%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 "-%.2d-%.2d_%.2d-%.2d-%.2d",
+                dt.year,
+                dt.mon,
+                dt.day,
+                dt.hour,
+                dt.min,
+                dt.sec);
         return std::string(buffer);
     }
 
@@ -741,7 +917,17 @@ namespace time_shield {
     inline const std::string to_windows_filename_ms(ts_ms_t ts) {
         DateTimeStruct dt = to_date_time_ms<DateTimeStruct>(ts);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2d_%.2d-%.2d-%.2d-%.3d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 "-%.2d-%.2d_%.2d-%.2d-%.2d-%.3d",
+                dt.year,
+                dt.mon,
+                dt.day,
+                dt.hour,
+                dt.min,
+                dt.sec,
+                dt.ms);
         return std::string(buffer);
     }
 
@@ -751,7 +937,16 @@ namespace time_shield {
     inline std::string to_human_readable(ts_t ts) {
         DateTimeStruct dt = to_date_time_ms<DateTimeStruct>(ts);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2d %.2d:%.2d:%.2d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 "-%.2d-%.2d %.2d:%.2d:%.2d",
+                dt.year,
+                dt.mon,
+                dt.day,
+                dt.hour,
+                dt.min,
+                dt.sec);
         return std::string(buffer);
     }
 
@@ -761,7 +956,17 @@ namespace time_shield {
     inline std::string to_human_readable_ms(ts_ms_t ts) {
         DateTimeStruct dt = to_date_time_ms<DateTimeStruct>(ts);
         char buffer[32] = {0};
-        snprintf(buffer, sizeof(buffer), "%lld-%.2d-%.2d %.2d:%.2d:%.2d.%.3d", dt.year, dt.mon, dt.day, dt.hour, dt.min, dt.sec, dt.ms);
+        snprintf(
+                buffer,
+                sizeof(buffer),
+                "%" PRId64 "-%.2d-%.2d %.2d:%.2d:%.2d.%.3d",
+                dt.year,
+                dt.mon,
+                dt.day,
+                dt.hour,
+                dt.min,
+                dt.sec,
+                dt.ms);
         return std::string(buffer);
     }
 


### PR DESCRIPTION
## Summary
- include `<inttypes.h>` in `time_formatting.hpp`
- replace `%lld` format specifiers with `PRId64` macros and casts for 64-bit values

## Testing
- cmake -S . -B build
- cmake --build build

------
https://chatgpt.com/codex/tasks/task_e_68ce4fe6d504832c9e4487bade127462