### PR TITLE
refactor: inline workday date calculation

### DIFF
--- a/MQL5/Include/time_shield/time_conversions.mqh
+++ b/MQL5/Include/time_shield/time_conversions.mqh
@@ -1066,6 +1066,21 @@ double sec_to_fhour(long sec) {
     // UNIX day and minute helpers
     //----------------------------------------------------------------------
 
+    /// \brief Convert calendar date to UNIX day.
+    /// \param year Year component.
+    /// \param month Month component.
+    /// \param day Day component.
+    /// \return Number of days since UNIX epoch.
+    long date_to_unix_day(const long year, const int month, const int day) {
+       const long adj_y = year - (month <= 2 ? 1 : 0);
+       const long adj_m = month <= 2 ? month + 9 : month - 3;
+       const long era = (adj_y >= 0 ? adj_y : adj_y - 399) / 400;
+       const long yoe = adj_y - era * 400;
+       const long doy = (153 * adj_m + 2) / 5 + day - 1;
+       const long doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+       return era * 146097 + doe - 719468;
+    }
+
     /// \brief Get UNIX day from timestamp.
     /// \param ts Timestamp in seconds.
     /// \return Number of days since UNIX epoch.

--- a/MQL5/Include/time_shield/time_parser.mqh
+++ b/MQL5/Include/time_shield/time_parser.mqh
@@ -194,6 +194,34 @@ namespace time_shield {
        return true;
     }
 
+    /// \brief Parse ISO8601 string and check for workday using second precision.
+    /// \param str ISO8601 formatted string.
+    /// \return true when parsed timestamp is Monday through Friday.
+    bool is_workday(string str) {
+       long ts = 0;
+       if(!str_to_ts(str, ts))
+          return false;
+       return is_workday(ts);
+    }
+
+    /// \brief Alias for is_workday.
+    /// \copydoc is_workday(string)
+    bool workday(string str) { return is_workday(str); }
+
+    /// \brief Parse ISO8601 string and check for workday using millisecond precision.
+    /// \param str ISO8601 formatted string.
+    /// \return true when parsed timestamp is Monday through Friday.
+    bool is_workday_ms(string str) {
+       long ts = 0;
+       if(!str_to_ts_ms(str, ts))
+          return false;
+       return is_workday_ms(ts);
+    }
+
+    /// \brief Alias for is_workday_ms.
+    /// \copydoc is_workday_ms(string)
+    bool workday_ms(string str) { return is_workday_ms(str); }
+
     /// \brief Convert an ISO8601 string to a floating-point timestamp (fts_t).
     /// \param str The ISO8601 string.
     /// \param ts The floating-point timestamp to be filled.

--- a/MQL5/Include/time_shield/validation.mqh
+++ b/MQL5/Include/time_shield/validation.mqh
@@ -246,6 +246,58 @@ namespace time_shield {
        return is_day_off_unix_day(unix_day);
     }
 
+    /// \brief Check if the timestamp corresponds to a workday.
+    /// \param ts Timestamp in seconds.
+    /// \return true when the date is Monday through Friday.
+    bool is_workday(const long ts) {
+       return !is_day_off(ts);
+    }
+
+    /// \brief Alias for is_workday.
+    /// \copydoc is_workday(const long)
+    bool workday(const long ts) {
+       return is_workday(ts);
+    }
+
+    /// \brief Check if the millisecond timestamp corresponds to a workday.
+    /// \param ts_ms Timestamp in milliseconds.
+    /// \return true when the date is Monday through Friday.
+    bool is_workday_ms(const long ts_ms) {
+       return is_workday(ts_ms / MS_PER_SEC);
+    }
+
+    /// \brief Alias for is_workday_ms.
+    /// \copydoc is_workday_ms(const long)
+    bool workday_ms(const long ts_ms) {
+       return is_workday_ms(ts_ms);
+    }
+
+    /// \brief Check if the provided date represents a workday.
+    /// \param year Year component.
+    /// \param month Month component.
+    /// \param day Day component.
+    /// \return true when the date is valid and is Monday through Friday.
+    bool is_workday(const long year, const int month, const int day) {
+       if (!is_valid_date(year, month, day))
+          return false;
+
+       const long adj_y = year - (month <= 2 ? 1 : 0);
+       const long adj_m = month <= 2 ? month + 9 : month - 3;
+       const long era = (adj_y >= 0 ? adj_y : adj_y - 399) / 400;
+       const long yoe = adj_y - era * 400;
+       const long doy = (153 * adj_m + 2) / 5 + day - 1;
+       const long doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+       const long unix_day = era * 146097 + doe - 719468;
+
+       return !is_day_off_unix_day(unix_day);
+    }
+
+    /// \brief Alias for is_workday.
+    /// \copydoc is_workday(const long, const int, const int)
+    bool workday(const long year, const int month, const int day) {
+       return is_workday(year, month, day);
+    }
+
     /// \}
 
 }; // namespace time_shield

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ more academic solutions like `HowardHinnant/date`, the library:
 
 ## Features
 
-- **Date validation**—checks dates for leap years and weekends.
+- **Date validation**—checks dates for leap years, weekends, and workdays (including ISO8601 strings).
 - **Time formatting**—converts timestamps to strings with standard or custom
   templates.
 - **Conversions**—translates between second, millisecond and floating time
@@ -194,6 +194,22 @@ if (parse_iso8601("2024-11-25T14:30:00-05:30", dt, tz)) {
     ts_t ts_val = to_timestamp(dt) + to_offset(tz);
 }
 ```
+
+### Checking workdays
+
+```cpp
+#include <time_shield/validation.hpp>
+#include <time_shield/time_parser.hpp>
+
+using namespace time_shield;
+
+bool monday = is_workday(1710720000);                    // seconds timestamp
+bool monday_ms = is_workday_ms("2024-03-18T09:00:00.500Z"); // ISO8601 with milliseconds
+bool from_date = is_workday(2024, 3, 18);                 // year, month, day components
+bool from_str = is_workday("2024-03-18T09:00:00Z");     // ISO8601 string
+```
+
+The string helpers accept the same ISO8601 formats as `str_to_ts` / `str_to_ts_ms` and evaluate to `false` when parsing fails or the date falls on a weekend.
 
 ### Time zone conversion
 

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -21,7 +21,7 @@ portable, and suitable for scenarios like logging, serialization, MQL5 usage, an
 
 \section features_sec Features
 
-- Validation of dates and times
+- Validation of dates and times (including weekend and workday predicates)
 - Time and date formatting (standard and custom)
 - Time zone conversion functions
 - ISO8601 string parsing
@@ -83,6 +83,27 @@ Additional example files are located in the `examples/` folder:
 - `time_conversions_example.cpp` — convert between formats
 - `time_zone_conversions_example.cpp` — CET/EET ↔ GMT
 - `ntp_client_example.cpp` — NTP sync (Windows-only)
+
+\subsection workday_helpers Workday helpers
+
+Check whether a moment falls on a business day using timestamps, calendar components, or ISO8601 strings:
+
+\code{.cpp}
+#include <time_shield/validation.hpp>
+#include <time_shield/time_parser.hpp>
+
+using namespace time_shield;
+
+bool monday = is_workday(1710720000);                    // Unix seconds (2024-03-18)
+bool monday_ms = is_workday_ms("2024-03-18T09:00:00.250Z"); // ISO8601 with milliseconds
+bool from_date = is_workday(2024, 3, 18);                 // year, month, day components
+
+// Parsing failure or a weekend evaluates to false
+bool saturday = is_workday("2024-03-16T10:00:00Z");
+bool invalid = is_workday("not-a-date");
+\endcode
+
+The string overloads recognise the same ISO8601 formats handled by \ref time_shield::str_to_ts "str_to_ts" and \ref time_shield::str_to_ts_ms "str_to_ts_ms".
 
 \section install_sec Installation
 \subsection install_pkg Install and `find_package`

--- a/include/time_shield/time_conversion_aliases.hpp
+++ b/include/time_shield/time_conversion_aliases.hpp
@@ -10,11 +10,13 @@
 /// to functions like `ts`, `get_ts`, etc., which are defined via macros.
 /// This file should be included only at the end of `time_conversion.hpp`.
 
+#include <string>
+
 namespace time_shield {
-    
+
 /// \ingroup time_conversions
 /// \{
-    
+
     /// \brief Alias for get_unix_year function.
     /// \copydoc get_unix_year
     template<class T = year_t>
@@ -1975,7 +1977,27 @@ namespace time_shield {
     constexpr ts_t finish_of_min(ts_t ts = time_shield::ts()) noexcept {
         return end_of_min(ts);
     }
-    
+
+//------------------------------------------------------------------------------
+
+    /// \brief Alias for is_workday(ts_t).
+    /// \copydoc is_workday(ts_t)
+    TIME_SHIELD_CONSTEXPR inline bool workday(ts_t ts) noexcept {
+        return is_workday(ts);
+    }
+
+    /// \brief Alias for is_workday(ts_ms_t).
+    /// \copydoc is_workday(ts_ms_t)
+    TIME_SHIELD_CONSTEXPR inline bool workday_ms(ts_ms_t ts_ms) noexcept {
+        return is_workday_ms(ts_ms);
+    }
+
+    /// \brief Alias for is_workday(year_t, int, int).
+    /// \copydoc is_workday(year_t, int, int)
+    TIME_SHIELD_CONSTEXPR inline bool workday(year_t year, int month, int day) noexcept {
+        return is_workday(year, month, day);
+    }
+
 /// \}
 
 }; // namespace time_shield

--- a/include/time_shield/time_conversions.hpp
+++ b/include/time_shield/time_conversions.hpp
@@ -838,6 +838,34 @@ namespace time_shield {
 
 //------------------------------------------------------------------------------
 
+    /// \brief Convert a calendar date to UNIX day count.
+    ///
+    /// Calculates the number of days since the UNIX epoch (January 1, 1970)
+    /// for the provided calendar date components.
+    ///
+    /// \tparam Year Type of the year component.
+    /// \tparam Month Type of the month component.
+    /// \tparam Day Type of the day component.
+    /// \param year Year component of the date.
+    /// \param month Month component of the date.
+    /// \param day Day component of the date.
+    /// \return Number of days since the UNIX epoch.
+    template<class Year, class Month, class Day>
+    TIME_SHIELD_CONSTEXPR inline uday_t date_to_unix_day(
+            Year year,
+            Month month,
+            Day day) noexcept {
+        const int64_t y = static_cast<int64_t>(year) - (static_cast<int64_t>(month) <= 2 ? 1 : 0);
+        const int64_t m = static_cast<int64_t>(month) <= 2
+                ? static_cast<int64_t>(month) + 9
+                : static_cast<int64_t>(month) - 3;
+        const int64_t era = (y >= 0 ? y : y - 399) / 400;
+        const int64_t yoe = y - era * 400;
+        const int64_t doy = (153 * m + 2) / 5 + static_cast<int64_t>(day) - 1;
+        const int64_t doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+        return static_cast<uday_t>(era * 146097 + doe - 719468);
+    }
+
     /// \brief Get UNIX day.
     ///
     /// This function returns the number of days elapsed since the UNIX epoch.

--- a/include/time_shield/time_parser.hpp
+++ b/include/time_shield/time_parser.hpp
@@ -259,6 +259,40 @@ namespace time_shield {
         return false;
     }
 
+    /// \brief Parse an ISO8601 string and check if it falls on a workday using second precision.
+    /// \param str ISO8601 formatted string.
+    /// \return true if parsing succeeds and the timestamp corresponds to a workday, false otherwise.
+    inline bool is_workday(const std::string& str) {
+        ts_t ts = 0;
+        if (!str_to_ts(str, ts)) {
+            return false;
+        }
+        return is_workday(ts);
+    }
+
+    /// \brief Parse an ISO8601 string and check if it falls on a workday using millisecond precision.
+    /// \param str ISO8601 formatted string.
+    /// \return true if parsing succeeds and the timestamp corresponds to a workday, false otherwise.
+    inline bool is_workday_ms(const std::string& str) {
+        ts_ms_t ts = 0;
+        if (!str_to_ts_ms(str, ts)) {
+            return false;
+        }
+        return is_workday_ms(ts);
+    }
+
+    /// \brief Alias for is_workday(const std::string&).
+    /// \copydoc is_workday(const std::string&)
+    inline bool workday(const std::string& str) {
+        return is_workday(str);
+    }
+
+    /// \brief Alias for is_workday_ms(const std::string&).
+    /// \copydoc is_workday_ms(const std::string&)
+    inline bool workday_ms(const std::string& str) {
+        return is_workday_ms(str);
+    }
+
     /// \brief Convert an ISO8601 string to a floating-point timestamp (fts_t).
     /// \details This function parses a string in ISO8601 format and converts it to a floating-point timestamp.
     /// \param str The ISO8601 string.

--- a/tests/workday_validation_test.cpp
+++ b/tests/workday_validation_test.cpp
@@ -1,0 +1,39 @@
+#include <time_shield/validation.hpp>
+#include <time_shield/time_parser.hpp>
+#include <cassert>
+#include <string>
+
+/// \brief Validates the is_workday overload set.
+int main() {
+    using namespace time_shield;
+
+    const ts_t weekday_ts = 1710720000; // 2024-03-18 (Monday)
+    const ts_t weekend_ts = 1710547200; // 2024-03-16 (Saturday)
+
+    assert(is_workday(weekday_ts));
+    assert(!is_workday(weekend_ts));
+
+    const ts_ms_t weekday_ms = weekday_ts * MS_PER_SEC;
+    const ts_ms_t weekend_ms = weekend_ts * MS_PER_SEC + 500;
+
+    assert(is_workday_ms(weekday_ms));
+    assert(!is_workday_ms(weekend_ms));
+
+    assert(is_workday(2024, 3, 18));
+    assert(!is_workday(2024, 3, 16));
+
+    const std::string weekday_iso = "2024-03-18T00:00:00Z";
+    const std::string weekend_iso = "2024-03-16T00:00:00Z";
+    const std::string weekday_iso_ms = "2024-03-18T00:00:00.500Z";
+    const std::string weekend_iso_ms = "2024-03-16T00:00:00.500Z";
+
+    assert(is_workday(weekday_iso));
+    assert(!is_workday(weekend_iso));
+    assert(is_workday_ms(weekday_iso_ms));
+    assert(!is_workday_ms(weekend_iso_ms));
+
+    assert(!is_workday("not-a-date"));
+    assert(!is_workday_ms("2024-13-40T00:00:00.000Z"));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- move the calendar-to-unix-day helper into the conversion modules as `date_to_unix_day`
- inline the `(year, month, day)` workday validation logic in both the C++ and MQL layers to avoid the extra dependency

## Testing
- cmake -S . -B build
- cmake --build build --target workday_validation_test
- ./build/workday_validation_test

------
https://chatgpt.com/codex/tasks/task_e_68d262d1f6ec832c925168c1f8ff91b8