### PR TITLE
feat: promote workday helper utilities

### DIFF
--- a/MQL5/Include/time_shield/time_conversions.mqh
+++ b/MQL5/Include/time_shield/time_conversions.mqh
@@ -826,6 +826,112 @@ double sec_to_fhour(long sec) {
     /// \copydoc num_days_in_month_ts
     int days_in_month(long ts) { return num_days_in_month_ts(ts); }
 
+    //----------------------------------------------------------------------
+    // Workday boundary helpers
+    //----------------------------------------------------------------------
+
+    int first_workday_day(long year, int month) {
+       int days = num_days_in_month(year, month);
+       if(days <= 0) return 0;
+       for(int day = 1; day <= days; ++day) {
+          if(is_workday(year, month, day)) return day;
+       }
+       return 0;
+    }
+
+    int last_workday_day(long year, int month) {
+       int days = num_days_in_month(year, month);
+       if(days <= 0) return 0;
+       for(int day = days; day >= 1; --day) {
+          if(is_workday(year, month, day)) return day;
+       }
+       return 0;
+    }
+
+    int count_workdays_in_month(long year, int month) {
+       int days = num_days_in_month(year, month);
+       if(days <= 0) return 0;
+       int total = 0;
+       for(int day = 1; day <= days; ++day) {
+          if(is_workday(year, month, day)) ++total;
+       }
+       return total;
+    }
+
+    int workday_index_in_month(long year, int month, int day) {
+       if(!is_workday(year, month, day)) return 0;
+       int days = num_days_in_month(year, month);
+       if(days <= 0) return 0;
+       int index = 0;
+       for(int current = 1; current <= days; ++current) {
+          if(is_workday(year, month, current)) {
+             ++index;
+             if(current == day) return index;
+          }
+       }
+       return 0;
+    }
+
+    //----------------------------------------------------------------------
+    // Workday boundary predicates
+    //----------------------------------------------------------------------
+
+    bool is_first_workday_of_month(long year, int month, int day) {
+       return is_workday(year, month, day) && first_workday_day(year, month) == day;
+    }
+
+    bool is_within_first_workdays_of_month(long year, int month, int day, int count) {
+       if(count <= 0) return false;
+       int total = count_workdays_in_month(year, month);
+       if(count > total) return false;
+       int index = workday_index_in_month(year, month, day);
+       return index > 0 && index <= count;
+    }
+
+    bool is_last_workday_of_month(long year, int month, int day) {
+       return is_workday(year, month, day) && last_workday_day(year, month) == day;
+    }
+
+    bool is_within_last_workdays_of_month(long year, int month, int day, int count) {
+       if(count <= 0) return false;
+       int total = count_workdays_in_month(year, month);
+       if(count > total) return false;
+       int index = workday_index_in_month(year, month, day);
+       return index > 0 && index >= (total - count + 1);
+    }
+
+    bool is_first_workday_of_month(const long ts) {
+       return is_first_workday_of_month(get_year(ts), (int)month_of_year(ts), day_of_month(ts));
+    }
+
+    bool is_within_first_workdays_of_month(const long ts, int count) {
+       return is_within_first_workdays_of_month(get_year(ts), (int)month_of_year(ts), day_of_month(ts), count);
+    }
+
+    bool is_last_workday_of_month(const long ts) {
+       return is_last_workday_of_month(get_year(ts), (int)month_of_year(ts), day_of_month(ts));
+    }
+
+    bool is_within_last_workdays_of_month(const long ts, int count) {
+       return is_within_last_workdays_of_month(get_year(ts), (int)month_of_year(ts), day_of_month(ts), count);
+    }
+
+    bool is_first_workday_of_month_ms(const long ts_ms) {
+       return is_first_workday_of_month(ms_to_sec(ts_ms));
+    }
+
+    bool is_within_first_workdays_of_month_ms(const long ts_ms, int count) {
+       return is_within_first_workdays_of_month(ms_to_sec(ts_ms), count);
+    }
+
+    bool is_last_workday_of_month_ms(const long ts_ms) {
+       return is_last_workday_of_month(ms_to_sec(ts_ms));
+    }
+
+    bool is_within_last_workdays_of_month_ms(const long ts_ms, int count) {
+       return is_within_last_workdays_of_month(ms_to_sec(ts_ms), count);
+    }
+
     /// \brief Get number of days in a year.
     /// \param year Year value.
     /// \return Days in the year.

--- a/MQL5/Include/time_shield/time_parser.mqh
+++ b/MQL5/Include/time_shield/time_parser.mqh
@@ -222,6 +222,90 @@ namespace time_shield {
     /// \copydoc is_workday_ms(string)
     bool workday_ms(string str) { return is_workday_ms(str); }
 
+    /// \brief Parse ISO8601 string and check for the first workday of the month using second precision.
+    /// \param str ISO8601 formatted string.
+    /// \return true when the parsed timestamp is the first workday of its month.
+    bool is_first_workday_of_month(string str) {
+       long ts = 0;
+       if(!str_to_ts(str, ts))
+          return false;
+       return is_first_workday_of_month(ts);
+    }
+
+    /// \brief Parse ISO8601 string and check for the first workday of the month using millisecond precision.
+    /// \param str ISO8601 formatted string.
+    /// \return true when the parsed timestamp is the first workday of its month.
+    bool is_first_workday_of_month_ms(string str) {
+       long ts = 0;
+       if(!str_to_ts_ms(str, ts))
+          return false;
+       return is_first_workday_of_month_ms(ts);
+    }
+
+    /// \brief Parse ISO8601 string and check if it falls within the first N workdays of the month using second precision.
+    /// \param str ISO8601 formatted string.
+    /// \param count Number of leading workdays to test.
+    /// \return true when the parsed timestamp is within the requested range.
+    bool is_within_first_workdays_of_month(string str, int count) {
+       long ts = 0;
+       if(!str_to_ts(str, ts))
+          return false;
+       return is_within_first_workdays_of_month(ts, count);
+    }
+
+    /// \brief Parse ISO8601 string and check if it falls within the first N workdays of the month using millisecond precision.
+    /// \param str ISO8601 formatted string.
+    /// \param count Number of leading workdays to test.
+    /// \return true when the parsed timestamp is within the requested range.
+    bool is_within_first_workdays_of_month_ms(string str, int count) {
+       long ts = 0;
+       if(!str_to_ts_ms(str, ts))
+          return false;
+       return is_within_first_workdays_of_month_ms(ts, count);
+    }
+
+    /// \brief Parse ISO8601 string and check for the last workday of the month using second precision.
+    /// \param str ISO8601 formatted string.
+    /// \return true when the parsed timestamp is the last workday of its month.
+    bool is_last_workday_of_month(string str) {
+       long ts = 0;
+       if(!str_to_ts(str, ts))
+          return false;
+       return is_last_workday_of_month(ts);
+    }
+
+    /// \brief Parse ISO8601 string and check for the last workday of the month using millisecond precision.
+    /// \param str ISO8601 formatted string.
+    /// \return true when the parsed timestamp is the last workday of its month.
+    bool is_last_workday_of_month_ms(string str) {
+       long ts = 0;
+       if(!str_to_ts_ms(str, ts))
+          return false;
+       return is_last_workday_of_month_ms(ts);
+    }
+
+    /// \brief Parse ISO8601 string and check if it falls within the last N workdays of the month using second precision.
+    /// \param str ISO8601 formatted string.
+    /// \param count Number of trailing workdays to test.
+    /// \return true when the parsed timestamp is within the requested range.
+    bool is_within_last_workdays_of_month(string str, int count) {
+       long ts = 0;
+       if(!str_to_ts(str, ts))
+          return false;
+       return is_within_last_workdays_of_month(ts, count);
+    }
+
+    /// \brief Parse ISO8601 string and check if it falls within the last N workdays of the month using millisecond precision.
+    /// \param str ISO8601 formatted string.
+    /// \param count Number of trailing workdays to test.
+    /// \return true when the parsed timestamp is within the requested range.
+    bool is_within_last_workdays_of_month_ms(string str, int count) {
+       long ts = 0;
+       if(!str_to_ts_ms(str, ts))
+          return false;
+       return is_within_last_workdays_of_month_ms(ts, count);
+    }
+
     /// \brief Convert an ISO8601 string to a floating-point timestamp (fts_t).
     /// \param str The ISO8601 string.
     /// \param ts The floating-point timestamp to be filled.

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -103,6 +103,21 @@ bool saturday = is_workday("2024-03-16T10:00:00Z");
 bool invalid = is_workday("not-a-date");
 \endcode
 
+Locate the first and last trading days for a month and constrain schedules to the opening or closing workdays:
+
+\code{.cpp}
+using namespace time_shield;
+
+ts_t june28 = to_timestamp(2024, 6, 28);
+bool is_last = is_last_workday_of_month(june28);                 // true (Friday before a weekend)
+bool in_last_two = is_within_last_workdays_of_month(june28, 2);  // true for the final two workdays
+bool in_first_two = is_within_first_workdays_of_month(june28, 2);// false, trailing end of month
+
+bool first_from_str = is_first_workday_of_month("2024-09-02T09:00:00Z");
+bool window_from_str = is_within_first_workdays_of_month_ms(
+    "2024-09-03T09:00:00.250Z", 2);
+\endcode
+
 The string overloads recognise the same ISO8601 formats handled by \ref time_shield::str_to_ts "str_to_ts" and \ref time_shield::str_to_ts_ms "str_to_ts_ms".
 
 \section install_sec Installation

--- a/include/time_shield/time_parser.hpp
+++ b/include/time_shield/time_parser.hpp
@@ -293,6 +293,98 @@ namespace time_shield {
         return is_workday_ms(str);
     }
 
+    /// \brief Parse an ISO8601 string and check if it is the first workday of its month.
+    /// \param str ISO8601 formatted string.
+    /// \return true if parsing succeeds and the timestamp corresponds to the first workday of the month, false otherwise.
+    inline bool is_first_workday_of_month(const std::string& str) {
+        ts_t ts = 0;
+        if (!str_to_ts(str, ts)) {
+            return false;
+        }
+        return is_first_workday_of_month(ts);
+    }
+
+    /// \brief Parse an ISO8601 string and check if it is the first workday of its month (millisecond precision).
+    /// \param str ISO8601 formatted string.
+    /// \return true if parsing succeeds and the timestamp corresponds to the first workday of the month, false otherwise.
+    inline bool is_first_workday_of_month_ms(const std::string& str) {
+        ts_ms_t ts = 0;
+        if (!str_to_ts_ms(str, ts)) {
+            return false;
+        }
+        return is_first_workday_of_month_ms(ts);
+    }
+
+    /// \brief Parse an ISO8601 string and check if it falls within the first N workdays of its month.
+    /// \param str ISO8601 formatted string.
+    /// \param count Number of leading workdays to test against.
+    /// \return true if parsing succeeds and the timestamp corresponds to a workday ranked within the first N positions, false otherwise.
+    inline bool is_within_first_workdays_of_month(const std::string& str, int count) {
+        ts_t ts = 0;
+        if (!str_to_ts(str, ts)) {
+            return false;
+        }
+        return is_within_first_workdays_of_month(ts, count);
+    }
+
+    /// \brief Parse an ISO8601 string and check if it falls within the first N workdays of its month (millisecond precision).
+    /// \param str ISO8601 formatted string.
+    /// \param count Number of leading workdays to test against.
+    /// \return true if parsing succeeds and the timestamp corresponds to a workday ranked within the first N positions, false otherwise.
+    inline bool is_within_first_workdays_of_month_ms(const std::string& str, int count) {
+        ts_ms_t ts = 0;
+        if (!str_to_ts_ms(str, ts)) {
+            return false;
+        }
+        return is_within_first_workdays_of_month_ms(ts, count);
+    }
+
+    /// \brief Parse an ISO8601 string and check if it is the last workday of its month.
+    /// \param str ISO8601 formatted string.
+    /// \return true if parsing succeeds and the timestamp corresponds to the last workday of the month, false otherwise.
+    inline bool is_last_workday_of_month(const std::string& str) {
+        ts_t ts = 0;
+        if (!str_to_ts(str, ts)) {
+            return false;
+        }
+        return is_last_workday_of_month(ts);
+    }
+
+    /// \brief Parse an ISO8601 string and check if it is the last workday of its month (millisecond precision).
+    /// \param str ISO8601 formatted string.
+    /// \return true if parsing succeeds and the timestamp corresponds to the last workday of the month, false otherwise.
+    inline bool is_last_workday_of_month_ms(const std::string& str) {
+        ts_ms_t ts = 0;
+        if (!str_to_ts_ms(str, ts)) {
+            return false;
+        }
+        return is_last_workday_of_month_ms(ts);
+    }
+
+    /// \brief Parse an ISO8601 string and check if it falls within the last N workdays of its month.
+    /// \param str ISO8601 formatted string.
+    /// \param count Number of trailing workdays to test against.
+    /// \return true if parsing succeeds and the timestamp corresponds to a workday ranked within the final N positions, false otherwise.
+    inline bool is_within_last_workdays_of_month(const std::string& str, int count) {
+        ts_t ts = 0;
+        if (!str_to_ts(str, ts)) {
+            return false;
+        }
+        return is_within_last_workdays_of_month(ts, count);
+    }
+
+    /// \brief Parse an ISO8601 string and check if it falls within the last N workdays of its month (millisecond precision).
+    /// \param str ISO8601 formatted string.
+    /// \param count Number of trailing workdays to test against.
+    /// \return true if parsing succeeds and the timestamp corresponds to a workday ranked within the final N positions, false otherwise.
+    inline bool is_within_last_workdays_of_month_ms(const std::string& str, int count) {
+        ts_ms_t ts = 0;
+        if (!str_to_ts_ms(str, ts)) {
+            return false;
+        }
+        return is_within_last_workdays_of_month_ms(ts, count);
+    }
+
     /// \brief Convert an ISO8601 string to a floating-point timestamp (fts_t).
     /// \details This function parses a string in ISO8601 format and converts it to a floating-point timestamp.
     /// \param str The ISO8601 string.

--- a/tests/workday_boundaries_test.cpp
+++ b/tests/workday_boundaries_test.cpp
@@ -1,0 +1,97 @@
+#include <time_shield/time_conversions.hpp>
+#include <time_shield/time_parser.hpp>
+#include <cassert>
+#include <string>
+
+/// \brief Validates first/last workday helpers across overload sets.
+int main() {
+    using namespace time_shield;
+
+    const ts_t june_first = to_timestamp(2024, 6, 1);
+    const ts_t june_third = to_timestamp(2024, 6, 3);
+    const ts_t june_fourth = to_timestamp(2024, 6, 4);
+    const ts_t june_twenty_sixth = to_timestamp(2024, 6, 26);
+    const ts_t june_twenty_seventh = to_timestamp(2024, 6, 27);
+    const ts_t june_twenty_eighth = to_timestamp(2024, 6, 28);
+
+    assert(first_workday_day(2024, 6) == 3);
+    assert(last_workday_day(2024, 6) == 28);
+    assert(count_workdays_in_month(2024, 6) == 20);
+    assert(workday_index_in_month(2024, 6, 27) == 19);
+
+    assert(is_first_workday_of_month(june_third));
+    assert(!is_first_workday_of_month(june_first));
+    assert(!is_first_workday_of_month(june_fourth));
+
+    assert(is_first_workday_of_month(2024, 6, 3));
+    assert(!is_first_workday_of_month(2024, 6, 1));
+
+    const ts_ms_t june_third_ms = june_third * MS_PER_SEC + 250;
+    const ts_ms_t june_fourth_ms = june_fourth * MS_PER_SEC;
+    assert(is_first_workday_of_month_ms(june_third_ms));
+    assert(!is_first_workday_of_month_ms(june_fourth_ms));
+
+    assert(is_last_workday_of_month(june_twenty_eighth));
+    assert(!is_last_workday_of_month(june_twenty_seventh));
+
+    assert(is_last_workday_of_month(2024, 6, 28));
+    assert(!is_last_workday_of_month(2024, 6, 29));
+
+    assert(is_last_workday_of_month_ms(june_twenty_eighth * MS_PER_SEC));
+    assert(!is_last_workday_of_month_ms((june_twenty_eighth + SEC_PER_DAY) * MS_PER_SEC));
+
+    assert(is_within_first_workdays_of_month(june_third, 1));
+    assert(!is_within_first_workdays_of_month(june_fourth, 1));
+    assert(is_within_first_workdays_of_month(june_fourth, 2));
+    assert(!is_within_first_workdays_of_month(june_third, 0));
+    assert(!is_within_first_workdays_of_month(june_third, 25));
+
+    assert(is_within_first_workdays_of_month(2024, 6, 3, 1));
+    assert(!is_within_first_workdays_of_month(2024, 6, 4, 1));
+    assert(is_within_first_workdays_of_month(2024, 6, 4, 2));
+    assert(!is_within_first_workdays_of_month(2024, 6, 3, 30));
+
+    assert(is_within_first_workdays_of_month_ms(june_third_ms, 1));
+    assert(!is_within_first_workdays_of_month_ms(june_fourth_ms, 1));
+
+    assert(is_within_last_workdays_of_month(june_twenty_eighth, 1));
+    assert(is_within_last_workdays_of_month(june_twenty_seventh, 2));
+    assert(!is_within_last_workdays_of_month(june_twenty_sixth, 2));
+    assert(is_within_last_workdays_of_month(june_twenty_sixth, 3));
+    assert(!is_within_last_workdays_of_month(june_twenty_eighth, 0));
+    assert(!is_within_last_workdays_of_month(june_twenty_eighth, 40));
+
+    assert(is_within_last_workdays_of_month(2024, 6, 28, 1));
+    assert(is_within_last_workdays_of_month(2024, 6, 27, 2));
+    assert(!is_within_last_workdays_of_month(2024, 6, 27, 1));
+    assert(is_within_last_workdays_of_month(2024, 6, 26, 3));
+
+    assert(is_within_last_workdays_of_month_ms(june_twenty_eighth * MS_PER_SEC, 1));
+    assert(!is_within_last_workdays_of_month_ms(june_twenty_sixth * MS_PER_SEC, 2));
+
+    const std::string sept_first = "2024-09-02T09:00:00Z"; // Monday after a Sunday start
+    const std::string sept_second = "2024-09-03T09:00:00Z";
+    const std::string sept_first_ms = "2024-09-02T09:00:00.250Z";
+
+    assert(is_first_workday_of_month(sept_first));
+    assert(!is_first_workday_of_month(sept_second));
+    assert(is_first_workday_of_month_ms(sept_first_ms));
+    assert(!is_first_workday_of_month_ms("2024-09-03T09:00:00.250Z"));
+
+    assert(is_within_first_workdays_of_month(sept_second, 2));
+    assert(!is_within_first_workdays_of_month(sept_second, 1));
+    assert(is_within_first_workdays_of_month_ms("2024-09-03T09:00:00.000Z", 2));
+
+    assert(is_last_workday_of_month("2024-06-28T12:00:00Z"));
+    assert(is_last_workday_of_month_ms("2024-06-28T12:00:00.000Z"));
+    assert(!is_last_workday_of_month("2024-06-27T12:00:00Z"));
+
+    assert(is_within_last_workdays_of_month("2024-06-26T10:00:00Z", 3));
+    assert(!is_within_last_workdays_of_month("2024-06-26T10:00:00Z", 2));
+    assert(is_within_last_workdays_of_month_ms("2024-06-27T10:00:00.500Z", 2));
+
+    assert(!is_first_workday_of_month("not-a-date"));
+    assert(!is_within_first_workdays_of_month_ms("invalid", 2));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- expose the workday helper routines in time_conversions.hpp and document their behaviour
- update the workday predicates to call the public helpers instead of the detail namespace
- extend workday_boundaries_test to verify the helper outputs directly

## Testing
- cmake --build build
- ctest --test-dir build

------
https://chatgpt.com/codex/tasks/task_e_68d36f50379c832cad9ddf4bdded2f58