### PR TITLE
feat(ntp): eternal singleton for NtpTimeService with optional DLL linkage

### DIFF
--- a/include/time_shield/ntp_time_service.hpp
+++ b/include/time_shield/ntp_time_service.hpp
@@ -197,7 +197,9 @@ namespace time_shield {
 #define TIME_SHIELD_NTP_TIME_SERVICE_API
 #endif
 
-        extern "C" TIME_SHIELD_NTP_TIME_SERVICE_API NtpTimeServiceT<RunnerAlias>& ntp_time_service_instance() noexcept;
+        /// \brief Return the process-wide singleton instance from a DLL export.
+        /// \note All modules must use the same configuration macros to keep ABI consistent.
+        extern "C" TIME_SHIELD_NTP_TIME_SERVICE_API NtpTimeServiceT<RunnerAlias>& time_shield_ntp_time_service_instance() noexcept;
 #endif
 
         template <class RunnerT>
@@ -236,7 +238,7 @@ namespace time_shield {
         template <>
         struct NtpTimeServiceSingleton<RunnerAlias> final {
             static NtpTimeServiceT<RunnerAlias>& instance() noexcept {
-                return ntp_time_service_instance();
+                return time_shield_ntp_time_service_instance();
             }
         };
 #endif
@@ -261,7 +263,7 @@ namespace time_shield {
         NtpTimeServiceT& operator=(const NtpTimeServiceT&) = delete;
 
         /// \brief Start background measurements using stored interval.
-        /// \return True when background runner started.
+        /// \return True when background runner started and initial measurement succeeded.
         bool init() {
             return init(m_interval, m_measure_immediately);
         }
@@ -445,7 +447,7 @@ namespace time_shield {
                 return true;
             }
             const int64_t age = now_realtime_us() - last;
-            return age > max_age.count() * 1000;
+            return age > static_cast<int64_t>(max_age.count()) * 1000;
         }
 
         /// \brief Replace server list used for new runner instances.
@@ -647,7 +649,7 @@ namespace time_shield {
 
 #if defined(TIME_SHIELD_NTP_TIME_SERVICE_USE_DLL_SINGLETON) && defined(TIME_SHIELD_NTP_TIME_SERVICE_DLL_IMPLEMENTATION)
 namespace detail {
-    extern "C" TIME_SHIELD_NTP_TIME_SERVICE_API NtpTimeServiceT<RunnerAlias>& ntp_time_service_instance() noexcept {
+    extern "C" TIME_SHIELD_NTP_TIME_SERVICE_API NtpTimeServiceT<RunnerAlias>& time_shield_ntp_time_service_instance() noexcept {
         static NtpTimeServiceT<RunnerAlias>* p_instance = new NtpTimeServiceT<RunnerAlias>{};
         static bool is_registered = []() noexcept {
             shutdown_instance_ptr<RunnerAlias>() = p_instance;
@@ -785,6 +787,6 @@ namespace time_shield {
     };
 } // namespace time_shield
 
-#endif // _TIME_SHIELD_ENABLE_NTP_CLIENT
+#endif // TIME_SHIELD_ENABLE_NTP_CLIENT
 
 #endif // _TIME_SHIELD_NTP_TIME_SERVICE_HPP_INCLUDED

--- a/include/time_shield/ntp_time_service.hpp
+++ b/include/time_shield/ntp_time_service.hpp
@@ -595,10 +595,7 @@ namespace time_shield {
                     m_state = State::stopped;
                 }
             }
-            should_notify = true;
-            if (should_notify) {
-                m_cv.notify_all();
-            }
+            m_cv.notify_all();
             return is_ok;
         }
 

--- a/tests/ntp_time_service_test.cpp
+++ b/tests/ntp_time_service_test.cpp
@@ -15,7 +15,7 @@ int main() {
 
     service.shutdown();
     assert(!service.running());
-    (void)service.utc_time_ms();
+    assert(service.init());
     assert(service.running());
 
     service.shutdown();

--- a/tests/ntp_time_service_test.cpp
+++ b/tests/ntp_time_service_test.cpp
@@ -2,7 +2,6 @@
 
 #if TIME_SHIELD_ENABLE_NTP_CLIENT
 #define TIME_SHIELD_TEST_FAKE_NTP
-#define TIME_SHIELD_NTP_TIME_SERVICE_DEFINE
 #include <time_shield/ntp_time_service.hpp>
 
 #include <cassert>

--- a/tests/odr/CMakeLists.txt
+++ b/tests/odr/CMakeLists.txt
@@ -14,3 +14,14 @@ target_link_libraries(odr_cxx17 PRIVATE time_shield::time_shield)
 set_target_properties(odr_cxx17 PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED YES)
 
 add_test(NAME odr_cxx17 COMMAND odr_cxx17)
+
+set(NTP_TIME_SERVICE_DLL_SOURCES
+    ntp_time_service_dll_a.cpp
+    ntp_time_service_dll_b.cpp
+)
+
+add_executable(ntp_time_service_dll_odr ${NTP_TIME_SERVICE_DLL_SOURCES})
+target_link_libraries(ntp_time_service_dll_odr PRIVATE time_shield::time_shield)
+set_target_properties(ntp_time_service_dll_odr PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED YES)
+
+add_test(NAME ntp_time_service_dll_odr COMMAND ntp_time_service_dll_odr)

--- a/tests/odr/ntp_time_service_dll_a.cpp
+++ b/tests/odr/ntp_time_service_dll_a.cpp
@@ -1,0 +1,22 @@
+#include <time_shield/config.hpp>
+
+#if TIME_SHIELD_ENABLE_NTP_CLIENT
+#define TIME_SHIELD_TEST_FAKE_NTP
+#define TIME_SHIELD_NTP_TIME_SERVICE_USE_DLL_SINGLETON
+#define TIME_SHIELD_NTP_TIME_SERVICE_DLL_EXPORTS
+#define TIME_SHIELD_NTP_TIME_SERVICE_DLL_IMPLEMENTATION
+#include <time_shield/ntp_time_service.hpp>
+
+int ntp_time_service_dll_helper();
+
+int main() {
+    auto& service = time_shield::NtpTimeService::instance();
+    service.shutdown();
+    (void)ntp_time_service_dll_helper();
+    return 0;
+}
+#else
+int main() {
+    return 0;
+}
+#endif

--- a/tests/odr/ntp_time_service_dll_b.cpp
+++ b/tests/odr/ntp_time_service_dll_b.cpp
@@ -1,0 +1,16 @@
+#include <time_shield/config.hpp>
+
+#if TIME_SHIELD_ENABLE_NTP_CLIENT
+#define TIME_SHIELD_TEST_FAKE_NTP
+#define TIME_SHIELD_NTP_TIME_SERVICE_USE_DLL_SINGLETON
+#define TIME_SHIELD_NTP_TIME_SERVICE_DLL_EXPORTS
+#include <time_shield/ntp_time_service.hpp>
+
+int ntp_time_service_dll_helper() {
+    return time_shield::NtpTimeService::instance().running() ? 1 : 0;
+}
+#else
+int ntp_time_service_dll_helper() {
+    return 0;
+}
+#endif


### PR DESCRIPTION
### Motivation
- Replace the previous ad-hoc singleton storage with a robust "eternal" singleton pattern that supports both header-only and DLL-backed singletons.
- Allow a single process-wide instance when building as a DLL to avoid ODR/multiple-instance issues.
- Keep changes minimal and localized to `ntp_time_service.hpp` and tests.
- Add an automated check that the DLL-singleton path compiles/links correctly under ODR test scenarios.

### Description
- Introduced a `detail::NtpTimeServiceSingleton` template and switched `NtpTimeServiceT::instance()` to return `detail::NtpTimeServiceSingleton<RunnerT>::instance()`.
- Added optional DLL macros: `TIME_SHIELD_NTP_TIME_SERVICE_USE_DLL_SINGLETON`, `TIME_SHIELD_NTP_TIME_SERVICE_DLL_EXPORTS`, and `TIME_SHIELD_NTP_TIME_SERVICE_DLL_IMPLEMENTATION` and `TIME_SHIELD_NTP_TIME_SERVICE_API` to control exported `ntp_time_service_instance()` linkage.
- Implemented the DLL-exported `ntp_time_service_instance()` (when `DLL_IMPLEMENTATION` is defined) and kept the header-only eternal-allocated instance as the default.
- Updated tests: removed the old define from `tests/ntp_time_service_test.cpp`, added ODR test sources `tests/odr/ntp_time_service_dll_a.cpp` and `tests/odr/ntp_time_service_dll_b.cpp`, and wired them into `tests/odr/CMakeLists.txt` to validate the DLL-singleton code path.

### Testing
- Configured tests and generated build files with `cmake -S . -B build -DTIME_SHIELD_CPP_BUILD_TESTS=ON` and configure succeeded.
- Built the project with `cmake --build build` and the build completed successfully.
- Executed tests with `ctest --test-dir build` and all tests passed (`36/36`).
- The new ODR/DLL test target `ntp_time_service_dll_odr` was built and ran as part of the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b86959ca0832ca712f02d52caa06c)